### PR TITLE
feat(service): Anthropic prompt caching on the system prompt

### DIFF
--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -464,6 +464,46 @@ def _rendered_prompt_to_overrides(rendered) -> dict[str, Any]:
     return overrides
 
 
+def _apply_prompt_caching(
+    model_string: str, messages: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Mark the system prompt as an Anthropic prompt-cache breakpoint.
+
+    Anthropic caches the prefix up to a block flagged with ``cache_control``.
+    Repeated calls that share the system prompt then read it at ~0.1x input
+    price instead of re-billing it in full — the dominant cost lever for
+    agent loops and any flow that re-sends a large stable system prompt.
+
+    Only ``anthropic/`` models are touched (LiteLLM forwards ``cache_control``
+    to the Anthropic API); every other provider is returned unchanged. Below
+    Anthropic's minimum cacheable length the flag is a silent no-op, so this is
+    safe for small one-shot prompts too.
+    """
+    if not model_string.startswith("anthropic/"):
+        return messages
+    out: list[dict[str, Any]] = []
+    marked = False
+    for msg in messages:
+        content = msg.get("content")
+        if not marked and msg.get("role") == "system" and isinstance(content, str):
+            out.append(
+                {
+                    "role": "system",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": content,
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
+                }
+            )
+            marked = True
+            continue
+        out.append(msg)
+    return out
+
+
 def _build_kwargs(
     config: dict[str, Any],
     messages: list[dict[str, Any]],
@@ -471,7 +511,7 @@ def _build_kwargs(
 ) -> dict[str, Any]:
     kwargs: dict[str, Any] = {
         "model": config["model_string"],
-        "messages": messages,
+        "messages": _apply_prompt_caching(config["model_string"], messages),
         "max_tokens": config.get("max_tokens", 2000),
         "temperature": config.get("temperature", 0.7),
     }

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5,7 +5,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aifw.schema import LLMResult, RenderedPromptProtocol
-from aifw.service import _build_model_string, _get_api_key, _parse_tool_calls
+from aifw.service import (
+    _apply_prompt_caching,
+    _build_kwargs,
+    _build_model_string,
+    _get_api_key,
+    _parse_tool_calls,
+)
 
 
 def test_build_model_string_openai():
@@ -402,3 +408,53 @@ def test_should_return_false_for_missing_action_code():
     from aifw.service import check_action_code
 
     assert check_action_code("nonexistent_action_xyz") is False
+
+
+# ---------------------------------------------------------------------------
+# Prompt caching (Anthropic) — _apply_prompt_caching / _build_kwargs wiring
+# ---------------------------------------------------------------------------
+
+
+def test_should_mark_system_prompt_with_cache_control_for_anthropic():
+    messages = [
+        {"role": "system", "content": "SYS"},
+        {"role": "user", "content": "U"},
+    ]
+    out = _apply_prompt_caching("anthropic/claude-opus-4-7", messages)
+    assert out[0]["content"] == [
+        {"type": "text", "text": "SYS", "cache_control": {"type": "ephemeral"}}
+    ]
+    assert out[1] == {"role": "user", "content": "U"}
+
+
+def test_should_not_touch_messages_for_non_anthropic_providers():
+    messages = [{"role": "system", "content": "SYS"}]
+    assert _apply_prompt_caching("groq/llama-3.3-70b-versatile", messages) is messages
+    assert _apply_prompt_caching("gpt-4o", messages) is messages
+
+
+def test_should_only_mark_first_system_block():
+    messages = [
+        {"role": "system", "content": "A"},
+        {"role": "system", "content": "B"},
+    ]
+    out = _apply_prompt_caching("anthropic/claude-haiku-4-5", messages)
+    assert isinstance(out[0]["content"], list)
+    assert out[1]["content"] == "B"
+
+
+def test_should_not_rewrap_already_structured_system_content():
+    messages = [{"role": "system", "content": [{"type": "text", "text": "X"}]}]
+    assert _apply_prompt_caching("anthropic/claude-opus-4-7", messages) == messages
+
+
+def test_should_passthrough_when_no_system_message():
+    messages = [{"role": "user", "content": "U"}]
+    assert _apply_prompt_caching("anthropic/claude-opus-4-7", messages) == messages
+
+
+def test_build_kwargs_applies_prompt_caching_for_anthropic():
+    config = {"model_string": "anthropic/claude-opus-4-7"}
+    messages = [{"role": "system", "content": "SYS"}, {"role": "user", "content": "U"}]
+    kwargs = _build_kwargs(config, messages, {})
+    assert kwargs["messages"][0]["content"][0]["cache_control"] == {"type": "ephemeral"}


### PR DESCRIPTION
## Why

aifw routes every LLM call through LiteLLM but never set `cache_control`. So each Anthropic call re-bills the **entire system prompt at 1x input** on every turn. For agent loops and any flow that re-sends a large stable prefix, that is the dominant cost driver — and the real lever behind the headless `claude-opus-4-7` spend (avg ~486k input tokens/call, frequently at the 1M context cap).

## What

`_apply_prompt_caching(model_string, messages)`:
- Marks the **first system message** as an ephemeral cache breakpoint (`cache_control: {"type": "ephemeral"}`) — LiteLLM forwards this to the Anthropic API.
- **Only `anthropic/*` models** are touched; groq/cerebras/openai/mistral are returned unchanged (same list object).
- Already-structured system content (a list of blocks) is left as-is — no double-wrapping.

Wired into `_build_kwargs`, the single chokepoint for `completion`, `completion_stream`, `sync_completion_stream`, and the `*_with_fallback` wrappers — so all paths benefit from one change.

## Effect

Cached prefixes read at **~0.1x input price** on hits (5-minute TTL). 

**Tradeoff (documented):** a large one-shot system prompt pays the ~1.25x cache-write premium with no reuse benefit; small prompts (typical Tier-1 background tasks) stay below Anthropic's minimum cacheable length and are unaffected. Net strongly positive for the repeated-prefix workloads that actually drive cost.

## Tests

6 new tests in `tests/test_service.py` (anthropic marks system, non-anthropic untouched, only-first-system, no-rewrap, no-system passthrough, `_build_kwargs` wiring). Full suite: **28 passed**.

## Test plan

- [ ] `pytest tests/test_service.py` green (28 passed locally)
- [ ] Live smoke against an Anthropic action_code: confirm 2nd identical call reports `cache_read_input_tokens > 0`
- [ ] Confirm a groq/cerebras action_code still works (no cache_control leaks to non-Anthropic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)