### PR TITLE
fix: derive __version__ from package metadata — behebt CI-Guard-Fail in allen Consumern (0.10.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — aifw
 
+## [0.10.3] — 2026-06-01
+
+### Fixed
+- **Version drift behoben:** `__version__` wurde in `pyproject.toml` (0.10.2) und `src/aifw/__init__.py` (0.10.0) doppelt gepflegt und driftete bei 0.10.1/0.10.2 auseinander. Das veröffentlichte Wheel trug `metadata=0.10.2 / code=0.10.0`, was den `iil-aifw metadata != code — stale tool-cache` CI-Guard (`platform/.github/actions/install-iil-packages`) in **allen** Consumern (dev-hub u.a.) hart fehlschlagen ließ.
+- `__version__` wird jetzt zur Laufzeit aus den Package-Metadaten gelesen (`importlib.metadata.version("iil-aifw")`) — **Single Source of Truth** ist `pyproject.toml`, Drift ist damit strukturell unmöglich.
+
 ## [0.10.2] — 2026-04-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iil-aifw"
-version = "0.10.2"
+version = "0.10.3"
 description = "Django AI Services Framework — DB-driven LLM routing, quality tiers, NL2SQL"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aifw/__init__.py
+++ b/src/aifw/__init__.py
@@ -12,7 +12,8 @@ New in 0.6.0:
     invalidate_action_cache() / invalidate_tier_cache()
 """
 
-__version__ = "0.10.0"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 from aifw.constants import QualityLevel
 from aifw.cost import estimate_cost
@@ -65,3 +66,12 @@ __all__ = [
     "sync_completion_stream",
     "sync_completion_with_fallback",
 ]
+
+# Single source of truth: the version lives in pyproject.toml and is read back
+# from the installed package metadata. Hardcoding it here caused metadata/code
+# drift (0.10.1/0.10.2 bumped pyproject but not this constant), which tripped the
+# `iil-aifw metadata != code` CI guard in every consumer. Never hardcode again.
+try:
+    __version__ = _pkg_version("iil-aifw")
+except PackageNotFoundError:  # editable/source checkout without installed dist
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Problem

`iil-aifw` pflegte die Version an **zwei** Stellen, die auseinanderdrifteten:

| Quelle | Wert |
|---|---|
| `pyproject.toml` (→ Package-Metadaten) | `0.10.2` |
| `src/aifw/__init__.py` `__version__` | `0.10.0` |

Bei 0.10.1/0.10.2 wurde `pyproject.toml` + CHANGELOG hochgezogen, `__version__` aber vergessen. Das **publizierte PyPI-Wheel** trägt diese Diskrepanz (`metadata=0.10.2 / code=0.10.0`).

## Auswirkung (repo-übergreifend)

Der CI-Guard in `platform/.github/actions/install-iil-packages/action.yml:89`
```python
sys.exit('::error::iil-aifw metadata %s != code %s — stale tool-cache not repaired') if code != meta else None
```
schlägt damit in **jedem Consumer** von `iil-aifw>=0.10.2` hart fehl (Unit/Integration-Jobs rot) — z.B. dev-hub. Der Guard kann „stale CI-Cache" nicht von „Package real fehlerhaft" unterscheiden; hier ist es Letzteres, also greift die Cache-Reparatur nicht.

## Fix

`__version__` wird zur Laufzeit aus den Package-Metadaten gelesen:
```python
from importlib.metadata import PackageNotFoundError, version as _pkg_version
try:
    __version__ = _pkg_version("iil-aifw")
except PackageNotFoundError:   # editable/source checkout ohne installierte dist
    __version__ = "0.0.0+unknown"
```
→ **Single Source of Truth = `pyproject.toml`**. Drift ist strukturell unmöglich. Bump auf **0.10.3**.

## Verifikation
- `ruff check` clean (I001 autofix)
- Ableitungslogik isoliert getestet: liefert die Metadaten-Version zurück
- kein hardcoded Versionsstring mehr im Code (nur im Erklär-Kommentar)
- kein Test erwartet einen hardgecodeten `__version__`

## Folge
Nach Publish von 0.10.3 nach PyPI: Consumer, die auf `>=0.10.3` heben (oder den stale Cache leeren), sind wieder grün. Der dev-hub-Pin `>=0.10.2,<0.11` zieht 0.10.3 automatisch.

## Empfohlene Nacharbeit (separat)
Der Guard selbst sollte „package-internal mismatch" von „stale cache" trennen — sonst bleibt er ein Fehlalarm-Risiko bei jedem künftigen Drift. platform-Repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)