### PR TITLE
fix(release): __version__ aus importlib.metadata + bump 0.10.3 (#11)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iil-aifw"
-version = "0.10.2"
+version = "0.10.3"
 description = "Django AI Services Framework — DB-driven LLM routing, quality tiers, NL2SQL"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aifw/__init__.py
+++ b/src/aifw/__init__.py
@@ -12,7 +12,14 @@ New in 0.6.0:
     invalidate_action_cache() / invalidate_tier_cache()
 """
 
-__version__ = "0.10.0"
+# Single source of truth: derive from installed package metadata
+# (pyproject.toml [project].version) so code & wheel can never drift again (#11).
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("iil-aifw")
+except PackageNotFoundError:  # editable/source checkout without install
+    __version__ = "0.0.0+unknown"
 
 from aifw.constants import QualityLevel
 from aifw.cost import estimate_cost


### PR DESCRIPTION
## Summary
Behebt die Metadaten/Code-Drift aus #11: Das publizierte `iil-aifw-0.10.2`-Wheel hatte im Code `__version__ = "0.10.0"`.

**Strukturelle Lösung statt manuellem Sync:** `__version__` wird jetzt via `importlib.metadata.version("iil-aifw")` aus der Package-Metadata (= `pyproject [project].version`) abgeleitet. Damit sind Code und Wheel **per Konstruktion** immer identisch — Drift ist nicht mehr möglich. Das ersetzt den in #11 alternativ vorgeschlagenen CI-String-Vergleich (`pyproject == __version__`), der nur detektiert statt verhindert.

## Changes
- `src/aifw/__init__.py`: `__version__` aus `importlib.metadata` (mit `PackageNotFoundError`-Fallback `0.0.0+unknown` für Source-Checkouts ohne Install).
- `pyproject.toml`: `0.10.2` → `0.10.3`.

## Release-Schritt (nach Merge, separat)
Dieser PR bumpt nur die Source. Das konsistente Wheel entsteht erst durch den **Release-Tag `v0.10.3`** → triggert `publish.yml` → PyPI. Bewusst NICHT Teil dieses PRs (irreversibler Publish).

## Verifikation
- `importlib.metadata.version("iil-aifw")` löst auf (liest installierte Metadata).
- Kein Test asserted `__version__` literal → keine Regression.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)