### PR TITLE
fix(service): wire quality-level routing + retry into completion path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — aifw
 
+## [0.11.0] — 2026-06-14
+
+### Fixed (Routing was advertised but inert — ADR-095/097)
+- **`completion()` / `completion_stream()` / `sync_completion_stream()` now actually route by `quality_level` + `priority`.** They previously called the legacy `get_model_config(action_code)`, which ignored both parameters — every call silently resolved the catch-all row. `get_model_config()` now drives the 4-step `_lookup_cascade` (exact → ql-only → prio-only → catch-all) and falls back to the global default / empty config as before.
+- **Tenacity retry layer is now wired in.** `_make_retry` / `_TRANSIENT_ERRORS` were defined but never applied; `completion()` now calls `litellm.acompletion` through `_acompletion_with_retry` (3 attempts, exponential backoff, transient errors only). Streaming paths are intentionally not retried mid-iteration.
+- **Completion-config shape now matches `_build_kwargs`.** The cascade path produces `api_base` + `api_key` (the legacy `ActionConfig` carried `base_url` / `api_key_env_var`, which `_build_kwargs` could not read). API keys are resolved fresh per call via `_resolve_api_key` and are no longer written to the shared cache.
+
+### Added
+- `completion_stream()` / `sync_completion_stream()` accept `quality_level` + `priority` (previously these would have leaked into litellm kwargs).
+- Regression tests proving routing reaches the selected model, retry behaviour, and that `invalidate_action_cache(code)` flushes the new `aifw:cfg:` cache keys.
+
+### Changed
+- Resolved config now caches under a dedicated `aifw:cfg:` key (was colliding-by-shape with `get_action_config`'s `aifw:action:` key); `invalidate_action_cache()` flushes both.
+
 ## [0.10.3] — 2026-06-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iil-aifw"
-version = "0.10.3"
+version = "0.11.0"
 description = "Django AI Services Framework — DB-driven LLM routing, quality tiers, NL2SQL"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -132,16 +132,32 @@ def _action_cache_key(code: str, quality_level: int | None, priority: str | None
 
 
 def _all_action_cache_keys_for_code(code: str) -> list[str]:
-    """Generate all possible cache keys for a given action code."""
+    """Generate all possible cache keys for a given action code.
+
+    Covers both the ActionConfig cache (get_action_config, 'aifw:action:') and
+    the resolved completion-config cache (get_model_config, 'aifw:cfg:') so a
+    single invalidate_action_cache(code) flushes every cached view of the code.
+    """
     keys = []
     for ql in [None, *QualityLevel.ALL]:
         for prio in [None, *VALID_PRIORITIES]:
             keys.append(_action_cache_key(code, ql, prio))
+            keys.append(_completion_cache_key(code, ql, prio))
     return keys
 
 
 def _tier_cache_key(tier: str) -> str:
     return f"aifw:tier:{tier}"
+
+
+def _completion_cache_key(
+    code: str, quality_level: int | None, priority: str | None
+) -> str:
+    """Cache key for the resolved completion config (distinct from the
+    ActionConfig key used by get_action_config to avoid a shape collision)."""
+    ql = str(quality_level) if quality_level is not None else "_"
+    prio = priority if priority is not None else "_"
+    return f"aifw:cfg:{code}:{ql}:{prio}"
 
 
 # ---------------------------------------------------------------------------
@@ -393,6 +409,16 @@ except ImportError:
         return fn
 
 
+@_make_retry
+async def _acompletion_with_retry(**kwargs: Any) -> Any:
+    """litellm.acompletion wrapped with tenacity retry on transient errors.
+
+    Applied to non-streaming completions only — streaming responses must not
+    be retried mid-iteration. No-op passthrough when tenacity is unavailable.
+    """
+    return await litellm.acompletion(**kwargs)
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -404,8 +430,13 @@ def _build_model_string(provider_name: str, model_name: str) -> str:
     return f"{provider}/{model_name}"
 
 
-def _get_api_key(provider) -> str:
-    env_var = provider.api_key_env_var or ""
+def _resolve_api_key(provider_name: str, env_var: str) -> str:
+    """Resolve an API key from the environment by explicit env var first, then
+    by a provider-name fallback map. Returns '' if nothing is configured.
+
+    Kept separate from cached config so secrets are never written to the
+    shared cache — the key is re-resolved fresh on every call.
+    """
     if env_var:
         return os.environ.get(env_var, "")
     fallback_map = {
@@ -414,9 +445,12 @@ def _get_api_key(provider) -> str:
         "google": "GOOGLE_API_KEY",
         "gemini": "GEMINI_API_KEY",
     }
-    name = provider.name.lower()
-    env_var = fallback_map.get(name, "")
+    env_var = fallback_map.get(provider_name.lower(), "")
     return os.environ.get(env_var, "") if env_var else ""
+
+
+def _get_api_key(provider) -> str:
+    return _resolve_api_key(provider.name, provider.api_key_env_var or "")
 
 
 def _parse_tool_calls(message) -> list[ToolCall]:
@@ -529,40 +563,58 @@ def _build_kwargs(
 # Legacy: get_model_config (backwards-compatible wrapper)
 # ---------------------------------------------------------------------------
 
-async def get_model_config(action_code: str) -> dict[str, Any]:
-    """Load model config from DB with hybrid cache. Legacy API — 0.5.x compatible.
+def _with_api_key(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a cached config with the api_key resolved fresh."""
+    cfg = dict(cfg)
+    cfg["api_key"] = _resolve_api_key(
+        cfg.get("provider_name", ""), cfg.get("api_key_env_var", "")
+    )
+    return cfg
 
-    New code should use get_action_config() instead.
+
+async def get_model_config(
+    action_code: str,
+    quality_level: int | None = None,
+    priority: str | None = None,
+) -> dict[str, Any]:
+    """Resolve the completion config for (action_code, quality_level, priority).
+
+    Routes via the 4-step lookup cascade (ADR-097 §5.1): exact → ql-only →
+    prio-only → catch-all. Falls back to the global default model when no
+    AIActionType row matches at all, and to an empty config (graceful error)
+    when the DB is unavailable.
+
+    Returns a dict consumable by _build_kwargs. The api_key is resolved fresh
+    on every call via _resolve_api_key and is never written to the shared cache.
     """
-    cache_key = _action_cache_key(action_code, None, None)
+    cache_key = _completion_cache_key(action_code, quality_level, priority)
     cached = _cache_get(cache_key)
     if cached is not None:
-        return cached
+        return _with_api_key(cached)
 
     try:
-        from aifw.models import AIActionType, LLMModel
+        from aifw.models import LLMModel
         from django.db import close_old_connections
 
         await sync_to_async(close_old_connections)()
 
-        action = await sync_to_async(
-            lambda: AIActionType.objects.select_related(
-                "default_model__provider",
-                "fallback_model__provider",
-            )
-            .filter(code=action_code, is_active=True)
-            .first()
-        )()
+        def _routed_action():
+            try:
+                return _lookup_cascade(action_code, quality_level, priority)
+            except ConfigurationError:
+                return None
 
-        if action:
-            model = action.get_model()
+        action = await sync_to_async(_routed_action)()
+
+        if action is not None:
+            model = await sync_to_async(action.get_model)()
             if model and model.provider:
                 cfg = {
                     "model_string": _build_model_string(
                         model.provider.name, model.name
                     ),
-                    "api_key": _get_api_key(model.provider),
                     "api_base": model.provider.base_url or None,
+                    "api_key_env_var": model.provider.api_key_env_var or "",
                     "max_tokens": action.max_tokens,
                     "temperature": action.temperature,
                     "action_id": action.id,
@@ -571,8 +623,9 @@ async def get_model_config(action_code: str) -> dict[str, Any]:
                     "model_name": model.name,
                 }
                 _cache_set(cache_key, cfg)
-                return cfg
+                return _with_api_key(cfg)
 
+        # No routed row for this code → global default model (legacy 0.5.x).
         global_default = await sync_to_async(
             lambda: LLMModel.objects.select_related("provider")
             .filter(is_default=True, is_active=True)
@@ -584,8 +637,8 @@ async def get_model_config(action_code: str) -> dict[str, Any]:
                 "model_string": _build_model_string(
                     global_default.provider.name, global_default.name
                 ),
-                "api_key": _get_api_key(global_default.provider),
                 "api_base": global_default.provider.base_url or None,
+                "api_key_env_var": global_default.provider.api_key_env_var or "",
                 "max_tokens": 2000,
                 "temperature": 0.7,
                 "action_id": None,
@@ -594,7 +647,7 @@ async def get_model_config(action_code: str) -> dict[str, Any]:
                 "model_name": global_default.name,
             }
             _cache_set(cache_key, cfg)
-            return cfg
+            return _with_api_key(cfg)
 
     except Exception as e:
         logger.warning("DB config unavailable for '%s': %s", action_code, e)
@@ -710,7 +763,7 @@ async def completion(
             overrides.setdefault(k, v)
         messages = _rendered_prompt_to_messages(messages)
 
-    config = await get_model_config(action_code)
+    config = await get_model_config(action_code, quality_level, priority)
     kwargs = _build_kwargs(config, messages, dict(overrides))
     if tools:
         kwargs["tools"] = tools
@@ -725,7 +778,7 @@ async def completion(
 
     start_time = time.perf_counter()
     try:
-        response = await litellm.acompletion(**kwargs)
+        response = await _acompletion_with_retry(**kwargs)
         latency_ms = int((time.perf_counter() - start_time) * 1000)
         choice = response.choices[0]
         message = choice.message
@@ -766,6 +819,8 @@ async def completion_stream(
     messages: list[dict[str, Any]] | Any,
     tools: list[dict[str, Any]] | None = None,
     tool_choice: str | None = "auto",
+    quality_level: int | None = None,
+    priority: str | None = None,
     **overrides: Any,
 ) -> AsyncIterator[str]:
     """Async streaming completion — yields text chunks as they arrive."""
@@ -775,7 +830,7 @@ async def completion_stream(
             overrides.setdefault(k, v)
         messages = _rendered_prompt_to_messages(messages)
 
-    config = await get_model_config(action_code)
+    config = await get_model_config(action_code, quality_level, priority)
     kwargs = _build_kwargs(config, messages, dict(overrides))
     kwargs["stream"] = True
     if tools:
@@ -793,6 +848,8 @@ async def completion_stream(
 def sync_completion_stream(
     action_code: str,
     messages: list[dict[str, Any]] | Any,
+    quality_level: int | None = None,
+    priority: str | None = None,
     **overrides: Any,
 ):
     """Synchronous streaming generator — for Django StreamingHttpResponse."""
@@ -808,7 +865,7 @@ def sync_completion_stream(
 
     async def _produce() -> None:
         try:
-            config = await get_model_config(action_code)
+            config = await get_model_config(action_code, quality_level, priority)
             kwargs = _build_kwargs(config, messages, dict(overrides))
             kwargs["stream"] = True
             response = await litellm.acompletion(**kwargs)

--- a/tests/test_routing_integration.py
+++ b/tests/test_routing_integration.py
@@ -1,0 +1,207 @@
+"""Regression tests: quality-level / priority routing and retry are actually
+wired into the completion path (not just the isolated _lookup_cascade).
+
+Guards the 0.10.3 fix where completion()/*_stream() called the legacy
+get_model_config(action_code) and silently ignored quality_level + priority.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aifw.service import _LOCAL_CACHE
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Process-local config cache must not leak model choices across tests."""
+    _LOCAL_CACHE.clear()
+    yield
+    _LOCAL_CACHE.clear()
+
+
+@pytest.fixture()
+def provider(transactional_db):
+    # transactional_db (committed rows) is required: completion() reads config
+    # via sync_to_async, i.e. from a worker thread. Under the default atomic
+    # test wrapper that read deadlocks on SQLite shared-cache ("table is locked").
+    from aifw.models import LLMProvider
+    return LLMProvider.objects.create(name="openai", api_key_env_var="OPENAI_API_KEY")
+
+
+@pytest.fixture()
+def models(provider):
+    from aifw.models import LLMModel
+    economy = LLMModel.objects.create(name="gpt-4o-mini", provider=provider, is_active=True)
+    premium = LLMModel.objects.create(name="gpt-4o", provider=provider, is_active=True)
+    return economy, premium
+
+
+def _action(code, model, quality_level=None, priority=None):
+    from aifw.models import AIActionType
+    return AIActionType.objects.create(
+        code=code,
+        name=f"{code} ql={quality_level} prio={priority}",
+        default_model=model,
+        quality_level=quality_level,
+        priority=priority,
+        is_active=True,
+        max_tokens=500,
+        temperature=0.7,
+    )
+
+
+def _fake_response(content="ok"):
+    message = MagicMock()
+    message.content = content
+    message.tool_calls = None
+    choice = MagicMock(message=message, finish_reason="stop")
+    response = MagicMock(choices=[choice], model="captured")
+    response.usage = MagicMock(prompt_tokens=10, completion_tokens=5)
+    return response
+
+
+# ── #1: routing actually reaches litellm ──────────────────────────────────────
+
+@pytest.mark.django_db(transaction=True)
+def test_should_route_quality_level_to_premium_model(models):
+    """completion(quality_level=8) must reach the ql=8 row's model, not catch-all."""
+    economy, premium = models
+    _action("story", economy, quality_level=None, priority=None)  # catch-all
+    _action("story", premium, quality_level=8, priority=None)     # premium
+
+    captured = {}
+
+    async def _capture(**kwargs):
+        captured["model"] = kwargs["model"]
+        return _fake_response()
+
+    from aifw.service import sync_completion
+
+    with patch("litellm.acompletion", side_effect=_capture), \
+         patch("aifw.service._log_usage", new=AsyncMock()):
+        result = sync_completion(
+            "story", [{"role": "user", "content": "hi"}], quality_level=8
+        )
+
+    assert result.success is True
+    assert captured["model"] == "gpt-4o"  # premium row, NOT the catch-all gpt-4o-mini
+
+
+@pytest.mark.django_db(transaction=True)
+def test_should_fall_back_to_catch_all_without_quality_level(models):
+    """completion() with no quality_level resolves the catch-all row's model."""
+    economy, premium = models
+    _action("story", economy, quality_level=None, priority=None)  # catch-all
+    _action("story", premium, quality_level=8, priority=None)
+
+    captured = {}
+
+    async def _capture(**kwargs):
+        captured["model"] = kwargs["model"]
+        return _fake_response()
+
+    from aifw.service import sync_completion
+
+    with patch("litellm.acompletion", side_effect=_capture), \
+         patch("aifw.service._log_usage", new=AsyncMock()):
+        result = sync_completion("story", [{"role": "user", "content": "hi"}])
+
+    assert result.success is True
+    assert captured["model"] == "gpt-4o-mini"  # catch-all row
+
+
+@pytest.mark.django_db(transaction=True)
+def test_should_route_priority_to_matching_row(models):
+    """completion(priority='quality') reaches the prio-specific row."""
+    economy, premium = models
+    _action("draft", economy, quality_level=None, priority=None)        # catch-all
+    _action("draft", premium, quality_level=None, priority="quality")   # prio-only
+
+    captured = {}
+
+    async def _capture(**kwargs):
+        captured["model"] = kwargs["model"]
+        return _fake_response()
+
+    from aifw.service import sync_completion
+
+    with patch("litellm.acompletion", side_effect=_capture), \
+         patch("aifw.service._log_usage", new=AsyncMock()):
+        sync_completion("draft", [{"role": "user", "content": "hi"}], priority="quality")
+
+    assert captured["model"] == "gpt-4o"
+
+
+# ── #1b: invalidation flushes the completion-config cache ─────────────────────
+
+def test_should_invalidate_completion_config_cache_for_code():
+    """invalidate_action_cache(code) must flush 'aifw:cfg:' completion keys,
+    not only the 'aifw:action:' ActionConfig keys."""
+    from aifw.service import (
+        _completion_cache_key,
+        _LOCAL_CACHE,
+        _local_set,
+        invalidate_action_cache,
+    )
+
+    key = _completion_cache_key("story", 8, "quality")
+    _local_set(key, {"model_string": "gpt-4o"})
+    assert key in _LOCAL_CACHE
+
+    invalidate_action_cache("story")
+    assert key not in _LOCAL_CACHE
+
+
+# ── #2: retry is applied to the completion call ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_should_retry_transient_error_then_succeed():
+    """_acompletion_with_retry retries transient errors instead of failing once."""
+    from aifw.service import _RETRY_ENABLED, _TRANSIENT_ERRORS, _acompletion_with_retry
+
+    if not _RETRY_ENABLED:
+        pytest.skip("tenacity not installed — retry layer disabled")
+
+    exc_cls = _TRANSIENT_ERRORS[0]
+    try:
+        transient = exc_cls(message="rate limited", llm_provider="openai", model="gpt-4o")
+    except TypeError:
+        transient = exc_cls("rate limited")
+
+    calls = {"n": 0}
+
+    async def _flaky(**kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise transient
+        return _fake_response()
+
+    # Skip tenacity's exponential backoff sleeps to keep the test fast.
+    with patch("tenacity.nap.sleep", lambda *_a, **_k: None), \
+         patch("asyncio.sleep", new=AsyncMock()), \
+         patch("litellm.acompletion", side_effect=_flaky):
+        response = await _acompletion_with_retry(model="gpt-4o", messages=[])
+
+    assert calls["n"] == 3  # 2 transient failures, succeeded on the 3rd attempt
+    assert response.model == "captured"
+
+
+@pytest.mark.asyncio
+async def test_should_not_retry_non_transient_error():
+    """Non-transient errors propagate immediately (single attempt)."""
+    from aifw.service import _RETRY_ENABLED, _acompletion_with_retry
+
+    if not _RETRY_ENABLED:
+        pytest.skip("tenacity not installed — retry layer disabled")
+
+    calls = {"n": 0}
+
+    async def _boom(**kwargs):
+        calls["n"] += 1
+        raise ValueError("non-transient")
+
+    with patch("litellm.acompletion", side_effect=_boom):
+        with pytest.raises(ValueError):
+            await _acompletion_with_retry(model="gpt-4o", messages=[])
+
+    assert calls["n"] == 1  # not retried


### PR DESCRIPTION
## Problem

Three advertised features were **inert in the live completion path** — plumbed through signatures, documented in README/docstrings/ADR-095/097, but never actually executed:

1. **Quality-level / priority routing** — `completion()` / `completion_stream()` / `sync_completion_stream()` called the legacy `get_model_config(action_code)`, which ignores `quality_level` + `priority`. Every call silently resolved the catch-all row. The `_lookup_cascade` cascade was tested in isolation (`test_lookup_cascade.py`) but never reached from a completion.
2. **Tenacity retry layer** — `_make_retry` / `_TRANSIENT_ERRORS` / `_RETRY_ENABLED` were defined but applied to **no** call site; `litellm.acompletion` ran without retries.
3. **Config shape mismatch** — `get_action_config()`/`ActionConfig` exposes `base_url` / `api_key_env_var`, but `_build_kwargs` reads `api_base` / `api_key`. Even a naive swap would have dropped the API key/base.

The existing `test_service.py` patched `get_model_config` away, which masked the bug.

## Fix

- `get_model_config()` now drives the 4-step `_lookup_cascade` (exact → ql-only → prio-only → catch-all), falling back to the global default / empty config as before. It returns a `_build_kwargs`-compatible dict (`api_base` + `api_key`). **API keys are resolved fresh per call and never written to the shared cache.**
- `completion()` calls litellm through `_acompletion_with_retry` (3 attempts, exponential backoff, transient errors only). Streaming paths are intentionally **not** retried mid-iteration.
- `completion_stream()` / `sync_completion_stream()` gain explicit `quality_level` + `priority` params (previously they'd have leaked into litellm kwargs).
- Dedicated `aifw:cfg:` cache key (was colliding-by-shape with `get_action_config`'s `aifw:action:` key); `invalidate_action_cache()` flushes both prefixes.
- `action.get_model()` now runs inside `sync_to_async` (the old code called sync ORM directly in an async context).
- `aifw.__version__` realigned with `pyproject.toml` (was drifted at `0.10.0`); bump to **0.11.0**.

## Tests

123 → **129 passed**. New `tests/test_routing_integration.py`:
- routing reaches the selected model for `quality_level` and `priority` (would fail on old code: SQLite sorts the `quality_level=NULL` catch-all first, so `.first()` returned the wrong model)
- catch-all fallback when no routing args
- retry on transient error then success / no retry on non-transient
- `invalidate_action_cache(code)` flushes the new `aifw:cfg:` keys

## Scope / not included

- Pre-existing unrelated change to `.windsurf/rules/mcp-tools.md` is **not** part of this PR.
- Board items #5 (ruff in CI), #6 (cost table), #7 (NL2SQL read-only guard) are deliberately left for follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)