### PR TITLE
chore(ci): gate CI on ruff and clear all lint violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,8 @@ jobs:
           pip install --upgrade pip
           pip install -e ".[dev]"
 
+      - name: Lint with ruff
+        run: ruff check src/ tests/
+
       - name: Run tests
         run: pytest tests/ -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,18 @@ pythonpath = ["src", "."]
 
 [tool.ruff]
 line-length = 100
+# Django migrations are auto-generated; linting them fights the generator.
+extend-exclude = ["**/migrations/**"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+# NL2SQL prompt/data modules: the long lines are German LLM-prompt text,
+# embedded SQL and glossary/regex literals *inside* string literals — they
+# cannot carry a line-level `# noqa`, and wrapping them would alter the prompt
+# or SQL. E501 is low-value here; every other rule (F, I) stays enforced.
+"src/aifw/nl2sql/semantic.py" = ["E501"]
+"src/aifw/nl2sql/engine.py" = ["E501"]
+"src/aifw/nl2sql/clarification.py" = ["E501"]
+"**/seed_nl2sql_examples.py" = ["E501"]

--- a/src/aifw/management/commands/check_aifw_config.py
+++ b/src/aifw/management/commands/check_aifw_config.py
@@ -69,7 +69,9 @@ class Command(BaseCommand):
             if has_catchall:
                 self.stdout.write(f"  {self.style.SUCCESS('OK')}  {code}")
             else:
-                self.stdout.write(f"  {self.style.ERROR('MISSING')}  {code} — no active catch-all row")
+                self.stdout.write(
+                    f"  {self.style.ERROR('MISSING')}  {code} — no active catch-all row"
+                )
                 missing.append(code)
 
         self.stdout.write("")

--- a/src/aifw/management/commands/validate_schema.py
+++ b/src/aifw/management/commands/validate_schema.py
@@ -124,7 +124,7 @@ class Command(BaseCommand):
                         self.stdout.write(f"    ✓ {col_name}")
 
             if not errors and not warnings:
-                self.stdout.write(self.style.SUCCESS(f"  → Schema vollständig valide"))
+                self.stdout.write(self.style.SUCCESS("  → Schema vollständig valide"))
             else:
                 for w in warnings:
                     self.stdout.write(self.style.WARNING(f"  WARN: {w}"))

--- a/src/aifw/nl2sql/engine.py
+++ b/src/aifw/nl2sql/engine.py
@@ -416,6 +416,7 @@ class NL2SQLEngine:
         """Load recent error patterns as anti-examples for the prompt."""
         try:
             from django.db.models import Count
+
             from aifw.nl2sql.models import NL2SQLFeedback
 
             patterns = (

--- a/src/aifw/nl2sql/management/commands/validate_schema.py
+++ b/src/aifw/nl2sql/management/commands/validate_schema.py
@@ -124,7 +124,7 @@ class Command(BaseCommand):
                         self.stdout.write(f"    ✓ {col_name}")
 
             if not errors and not warnings:
-                self.stdout.write(self.style.SUCCESS(f"  → Schema vollständig valide"))
+                self.stdout.write(self.style.SUCCESS("  → Schema vollständig valide"))
             else:
                 for w in warnings:
                     self.stdout.write(self.style.WARNING(f"  WARN: {w}"))

--- a/src/aifw/nl2sql/semantic.py
+++ b/src/aifw/nl2sql/semantic.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import Any
-
 
 # ── Data Classes (Django-free) ──────────────────────────────────────────────
 

--- a/src/aifw/schema.py
+++ b/src/aifw/schema.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from decimal import Decimal
 
 
 @runtime_checkable
@@ -58,7 +61,6 @@ class LLMResult:
 
     def estimate_cost(self) -> "Decimal":
         """Estimate cost of this LLM call. See :func:`aifw.estimate_cost`."""
-        from decimal import Decimal
 
         from aifw.cost import estimate_cost as _estimate_cost
 

--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -28,8 +28,8 @@ import json
 import logging
 import os
 import queue
-import time
 import threading
+import time
 import uuid
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
@@ -37,13 +37,13 @@ from typing import TYPE_CHECKING, Any
 import litellm
 from asgiref.sync import sync_to_async
 
-from aifw.constants import QualityLevel, VALID_PRIORITIES
+from aifw.constants import VALID_PRIORITIES, QualityLevel
 from aifw.exceptions import ConfigurationError
 from aifw.schema import LLMResult, RenderedPromptProtocol, ToolCall
 from aifw.types import ActionConfig
 
 if TYPE_CHECKING:
-    pass
+    from aifw.models import AIActionType
 
 logger = logging.getLogger(__name__)
 
@@ -278,7 +278,7 @@ def _to_action_config(action: "AIActionType") -> ActionConfig:  # type: ignore[n
             f"AIActionType {action.code!r} has no resolvable model. "
             f"Check default_model and fallback_model configuration."
         )
-    from aifw.service import _build_model_string, _get_api_key
+    from aifw.service import _build_model_string
     ms = _build_model_string(model.provider.name, model.name)
     return ActionConfig(
         action_id=action.id,
@@ -593,8 +593,9 @@ async def get_model_config(
         return _with_api_key(cached)
 
     try:
-        from aifw.models import LLMModel
         from django.db import close_old_connections
+
+        from aifw.models import LLMModel
 
         await sync_to_async(close_old_connections)()
 

--- a/tests/test_budget_cache.py
+++ b/tests/test_budget_cache.py
@@ -2,7 +2,7 @@
 
 import time
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,18 +1,16 @@
 """Tests for aifw cache invalidation (ADR-097 G-097-02/03)."""
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from aifw.service import (
+    _LOCAL_CACHE,
     _action_cache_key,
     _all_action_cache_keys_for_code,
-    _tier_cache_key,
     _cache_get,
     _cache_set,
-    _LOCAL_CACHE,
+    _tier_cache_key,
     invalidate_action_cache,
     invalidate_tier_cache,
 )
-
 
 # ── Cache key helpers ─────────────────────────────────────────────────────────
 

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -3,8 +3,6 @@
 from decimal import Decimal
 from unittest.mock import patch
 
-import pytest
-
 from aifw.cost import estimate_cost
 from aifw.schema import LLMResult
 

--- a/tests/test_log_usage.py
+++ b/tests/test_log_usage.py
@@ -7,7 +7,6 @@ DB write path introduced in migration 0003 / aifw 0.5.0.
 """
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 

--- a/tests/test_lookup_cascade.py
+++ b/tests/test_lookup_cascade.py
@@ -7,7 +7,6 @@ import pytest
 
 from aifw.exceptions import ConfigurationError
 
-
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
 @pytest.fixture()
@@ -131,7 +130,7 @@ def test_should_skip_step1_when_quality_level_is_none(model):
     """F-07: step 1 (exact) skipped when quality_level=None."""
     from aifw.service import _lookup_cascade
 
-    catchall = _action("write", model, quality_level=None, priority=None)
+    _action("write", model, quality_level=None, priority=None)  # catch-all (must be skipped)
     prio_only = _action("write", model, quality_level=None, priority="quality")
 
     # Without ql, step1 is impossible — step3 (prio-only) should match

--- a/tests/test_routing_integration.py
+++ b/tests/test_routing_integration.py
@@ -138,8 +138,8 @@ def test_should_invalidate_completion_config_cache_for_code():
     """invalidate_action_cache(code) must flush 'aifw:cfg:' completion keys,
     not only the 'aifw:action:' ActionConfig keys."""
     from aifw.service import (
-        _completion_cache_key,
         _LOCAL_CACHE,
+        _completion_cache_key,
         _local_set,
         invalidate_action_cache,
     )

--- a/tests/test_semantic_bridge.py
+++ b/tests/test_semantic_bridge.py
@@ -10,8 +10,6 @@ import pytest
 from aifw.nl2sql.semantic import (
     GlossaryEntry,
     SemanticBridge,
-    SemanticHints,
-    TemporalHint,
 )
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -238,6 +238,7 @@ async def test_completion_success():
 async def test_should_pass_tenant_id_to_log_usage():
     """completion() forwards tenant_id to _log_usage."""
     import uuid
+
     from aifw.service import completion
 
     tenant = uuid.uuid4()
@@ -360,6 +361,7 @@ def test_should_return_result_from_sync_completion_with_fallback():
 def test_should_propagate_tenant_id_through_sync_fallback():
     """sync_completion_with_fallback() passes tenant_id to completion_with_fallback."""
     import uuid
+
     from aifw.service import sync_completion_with_fallback
 
     captured = {}

--- a/tests/test_tier.py
+++ b/tests/test_tier.py
@@ -1,6 +1,6 @@
 """Tests for tier quality mapping (ADR-095/097 TierQualityMapping)."""
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 
 @pytest.fixture()
@@ -39,8 +39,8 @@ def test_should_return_quality_level_for_known_tier():
 @pytest.mark.django_db
 def test_should_return_none_for_unknown_tier():
     """get_quality_level_for_tier returns BALANCED (5) as default for unknown tier."""
-    from aifw.service import get_quality_level_for_tier
     from aifw.constants import QualityLevel
+    from aifw.service import get_quality_level_for_tier
 
     result = get_quality_level_for_tier("nonexistent_tier_xyz")
     assert result == QualityLevel.BALANCED
@@ -50,7 +50,7 @@ def test_should_return_none_for_unknown_tier():
 def test_should_use_cache_on_second_call(monkeypatch):
     """Second call uses cache — DB not queried again."""
     from aifw.models import TierQualityMapping
-    from aifw.service import get_quality_level_for_tier, _LOCAL_CACHE, _tier_cache_key
+    from aifw.service import _LOCAL_CACHE, _tier_cache_key, get_quality_level_for_tier
 
     TierQualityMapping.objects.create(tier="pro", quality_level=6)
     _LOCAL_CACHE.clear()
@@ -72,6 +72,7 @@ def test_should_use_cache_on_second_call(monkeypatch):
 def test_should_enforce_unique_tier():
     """Duplicate tier names must raise IntegrityError."""
     from django.db import IntegrityError
+
     from aifw.models import TierQualityMapping
 
     TierQualityMapping.objects.create(tier="enterprise", quality_level=9)


### PR DESCRIPTION
## Problem (board item #5)

CI ran `pytest` only. `make lint` existed but **nothing enforced it**, so 101 ruff violations had accumulated on `main` — including 13 unused imports (`F401`) and import-order drift (`I001`). Lint was effectively dead.

## What this does

Adds a `Lint with ruff` step to `ci.yml` and brings the tree to **zero** violations so the gate is meaningful and green:

- **Autofix (29):** import order (`I001`), unused imports (`F401`), f-strings without placeholders (`F541`), one dead test variable (`F841`).
- **`F821` false-positives** (string forward-ref annotations) resolved properly via `TYPE_CHECKING` imports — `AIActionType` in `service.py`, `Decimal` in `schema.py`.
- **Exclude auto-generated Django migrations** from lint (linting them fights the generator; they were ~34 of the violations).
- **Per-file `E501` ignore for the NL2SQL prompt/SQL-data modules** (`semantic.py`, `engine.py`, `clarification.py`, `seed_nl2sql_examples.py`). Their long lines are German LLM-prompt text / embedded SQL / glossary literals **inside string literals** — they can't carry a line-level `# noqa`, and wrapping them would alter the prompt or SQL. **`E501` stays enforced everywhere else**, as do `F` and `I` across the whole tree.
- **Wrapped** the one genuine over-length code line (`check_aifw_config.py`).

## Safety

No source behavior change — only import hygiene, type-checking imports, and lint config. **135 tests still pass**; `ruff check src/ tests/` exits 0 locally.

## Follow-ups (not in this PR)

Board #6 (stale cost-rate table) and #7 (NL2SQL read-only DB guard) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)