### PR TITLE
feat(nl2sql): execute LLM SQL in a read-only PostgreSQL transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — aifw
 
+## [0.11.1] — 2026-06-14
+
+### Security / Hardening (NL2SQL)
+- **LLM-generated SQL now runs inside a read-only PostgreSQL transaction.** `_execute_query` issues `SET TRANSACTION READ ONLY` before the query, so any write (INSERT/UPDATE/DELETE/DDL) that slips past the regex blocklist (`_validate_sql`) is rejected by the database itself with *"cannot execute … in a read-only transaction"*. The regex remains the first line of defence; the database is now the enforced one. Only `postgresql` connections are wrapped; if the target alias is already inside an atomic block the read-only guard cannot be applied and a warning is logged (degrades to regex-only, never silently).
+
+### Fixed
+- **`statement_timeout` was a silent no-op under autocommit.** `SET LOCAL statement_timeout` only takes effect inside a transaction; queries previously ran without the configured timeout. Now applied inside the read-only transaction, and `postgresql`-guarded so it no longer errors on non-PostgreSQL aliases.
+
 ## [0.11.0] — 2026-06-14
 
 ### Fixed (Routing was advertised but inert — ADR-095/097)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iil-aifw"
-version = "0.11.0"
+version = "0.11.1"
 description = "Django AI Services Framework — DB-driven LLM routing, quality tiers, NL2SQL"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aifw/nl2sql/engine.py
+++ b/src/aifw/nl2sql/engine.py
@@ -258,18 +258,46 @@ def _execute_query(
     max_rows: int,
     timeout_seconds: int,
 ) -> tuple[list[dict], list[list], float, bool]:
-    from django.db import connections
+    from django.db import connections, transaction
 
     conn = connections[db_alias]
+    is_postgres = conn.vendor == "postgresql"
+    # SET TRANSACTION READ ONLY must be the first statement of its transaction,
+    # so we only own the transaction when not already inside one.
+    own_txn = is_postgres and not conn.in_atomic_block
+    if is_postgres and not own_txn:
+        logger.warning(
+            "NL2SQL: db alias %r already in an atomic block — cannot enforce a "
+            "read-only transaction; relying on _validate_sql only.",
+            db_alias,
+        )
+    limited_sql = _inject_limit(sql, max_rows + 1)
     start = time.perf_counter()
 
-    with conn.cursor() as cursor:
-        if timeout_seconds > 0:
-            cursor.execute(f"SET LOCAL statement_timeout = {timeout_seconds * 1000}")
-        limited_sql = _inject_limit(sql, max_rows + 1)
-        cursor.execute(limited_sql)
-        raw_rows = cursor.fetchall()
-        description = cursor.description or []
+    def _fetch() -> tuple[list, list]:
+        with conn.cursor() as cursor:
+            if own_txn:
+                # Defence in depth: any write that slips past _validate_sql
+                # (regex blocklist) is rejected by PostgreSQL itself with
+                # "cannot execute ... in a read-only transaction". The regex is
+                # the first line of defence; this is the enforced one.
+                cursor.execute("SET TRANSACTION READ ONLY")
+            if is_postgres and timeout_seconds > 0:
+                # statement_timeout via SET LOCAL only takes effect inside a
+                # transaction — under autocommit it was previously a silent no-op.
+                cursor.execute(
+                    f"SET LOCAL statement_timeout = {timeout_seconds * 1000}"
+                )
+            cursor.execute(limited_sql)
+            return cursor.fetchall(), (cursor.description or [])
+
+    if own_txn:
+        with transaction.atomic(using=db_alias):
+            raw_rows, description = _fetch()
+            # Pure read — discard the transaction without COMMIT.
+            transaction.set_rollback(True, using=db_alias)
+    else:
+        raw_rows, description = _fetch()
 
     elapsed_ms = (time.perf_counter() - start) * 1000
     truncated = len(raw_rows) > max_rows

--- a/tests/test_nl2sql_readonly.py
+++ b/tests/test_nl2sql_readonly.py
@@ -1,0 +1,79 @@
+"""Defence-in-depth: NL2SQL executes LLM-generated SQL inside a read-only
+PostgreSQL transaction, so any write that slips past the regex blocklist
+(_validate_sql) is rejected by the database itself.
+
+These are pure unit tests over _execute_query with a faked DB connection —
+they assert the guard is *wired* (the statements issued, in order). The actual
+"cannot execute in a read-only transaction" rejection is a PostgreSQL behaviour
+and is not reproducible against the sqlite test DB.
+"""
+from unittest.mock import patch
+
+from aifw.nl2sql.engine import _execute_query
+
+
+class _FakeCursor:
+    def __init__(self):
+        self.executed: list[str] = []
+        self.description: list = []
+
+    def execute(self, sql):
+        self.executed.append(sql)
+
+    def fetchall(self):
+        return []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, vendor, in_atomic_block=False):
+        self.vendor = vendor
+        self.in_atomic_block = in_atomic_block
+        self._cursor = _FakeCursor()
+
+    def cursor(self):
+        return self._cursor
+
+
+def test_should_enforce_read_only_transaction_on_postgres():
+    conn = _FakeConn("postgresql")
+    with patch("django.db.connections", {"analytics": conn}), \
+         patch("django.db.transaction") as tx:
+        _execute_query("SELECT 1", db_alias="analytics", max_rows=100, timeout_seconds=5)
+
+    stmts = conn._cursor.executed
+    assert stmts[0] == "SET TRANSACTION READ ONLY"  # first statement of the txn
+    assert any("statement_timeout" in s for s in stmts)
+    assert stmts[-1].startswith("SELECT 1")  # the LLM SQL runs after the guards
+    tx.atomic.assert_called_once_with(using="analytics")
+    tx.set_rollback.assert_called_once()  # read-only — never commit
+
+
+def test_should_skip_read_only_when_already_in_atomic_block():
+    """Cannot set READ ONLY mid-transaction; degrade to regex-only (logged)."""
+    conn = _FakeConn("postgresql", in_atomic_block=True)
+    with patch("django.db.connections", {"analytics": conn}), \
+         patch("django.db.transaction") as tx:
+        _execute_query("SELECT 1", db_alias="analytics", max_rows=100, timeout_seconds=5)
+
+    stmts = conn._cursor.executed
+    assert all("READ ONLY" not in s for s in stmts)
+    tx.atomic.assert_not_called()
+
+
+def test_should_not_issue_postgres_only_statements_on_sqlite():
+    conn = _FakeConn("sqlite")
+    with patch("django.db.connections", {"analytics": conn}), \
+         patch("django.db.transaction") as tx:
+        _execute_query("SELECT 1", db_alias="analytics", max_rows=100, timeout_seconds=5)
+
+    stmts = conn._cursor.executed
+    assert all("READ ONLY" not in s for s in stmts)
+    assert all("statement_timeout" not in s for s in stmts)  # SET LOCAL no-op guard
+    tx.atomic.assert_not_called()
+    assert stmts == ["SELECT 1 LIMIT 101"]


### PR DESCRIPTION
## Problem (board item #7 — highest-severity finding)

`NL2SQLEngine` executes **LLM-generated SQL** via `_execute_query` on a normal DB connection. The only guard was a regex keyword blocklist (`_validate_sql`) — brittle (false-positives on aliases like `AS "Drop …"`, and a keyword inside a string literal can confuse it) and it is the *only* thing standing between a model hallucination / prompt-injection and a write to the database. There was no database-level enforcement.

## Fix — defence in depth

`_execute_query` now wraps execution in a transaction and issues `SET TRANSACTION READ ONLY` before the query. Any write (INSERT/UPDATE/DELETE/DDL) that slips past the regex is rejected by PostgreSQL itself: *"cannot execute … in a read-only transaction"*. The regex stays as the first line of defence; the database is now the **enforced** one.

- **Vendor-guarded** — only `postgresql` connections are wrapped (the NL2SQL system prompt targets PostgreSQL exclusively).
- **No silent degradation** — `SET TRANSACTION READ ONLY` must be the first statement of its transaction, so if the target alias is already inside an atomic block the guard can't be applied; that case logs a warning and falls back to regex-only rather than silently dropping the protection.
- The read-only transaction is rolled back (pure read, never commits).

### Bonus fix — latent `statement_timeout` no-op
`SET LOCAL statement_timeout` only takes effect inside a transaction; under Django autocommit it was a **silent no-op**, so queries ran without the configured timeout. It's now issued inside the read-only transaction (and postgres-guarded, so it no longer errors on non-PostgreSQL aliases).

## Tests
New `tests/test_nl2sql_readonly.py` (unit, faked connection): asserts `SET TRANSACTION READ ONLY` is issued **first** on postgres before the LLM SQL, skipped on sqlite, and skipped (with degradation) when already in an atomic block. The actual rejection is PostgreSQL runtime behaviour, not reproducible against the sqlite test DB — hence the wiring-level assertions. **138 tests pass**, ruff clean.

## Operational note (not code)
For full assurance the deployment should *also* point the NL2SQL `db_alias` at a DB role granted `SELECT`-only. This PR is the in-code guard; a least-privilege role is the complementary infra control.

Bumps **0.11.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)