### PR TITLE
fix(cost): drop stale fallback rate + consolidate cost arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — aifw
 
+## [0.11.2] — 2026-06-14
+
+### Fixed
+- **Stale cost fallback table:** removed the bogus `claude-sonnet-4-5-20250514` entry from `cost._FALLBACK_RATES` (an inconsistent, made-up snapshot id duplicating `claude-3-5-sonnet`'s rates). litellm remains the source of truth; the table is only a coarse last-resort fallback for models litellm does not recognise.
+
+### Changed
+- **Single cost-arithmetic helper:** new `cost.cost_from_rates(input_tokens, output_tokens, input_rate, output_rate)` is now the one place the per-million math lives. `estimate_cost()`'s fallback branch and `_log_usage()` (operator-configured DB rates) both use it instead of duplicating the formula. Exported as `aifw.cost_from_rates`. `_log_usage` now produces a `Decimal` (was `float`); `AIUsageLog.save()` still falls back to `estimate_cost()` when a model has no DB rates.
+
 ## [0.11.1] — 2026-06-14
 
 ### Security / Hardening (NL2SQL)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iil-aifw"
-version = "0.11.1"
+version = "0.11.2"
 description = "Django AI Services Framework — DB-driven LLM routing, quality tiers, NL2SQL"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aifw/__init__.py
+++ b/src/aifw/__init__.py
@@ -16,7 +16,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
 from aifw.constants import QualityLevel
-from aifw.cost import estimate_cost
+from aifw.cost import cost_from_rates, estimate_cost
 from aifw.exceptions import AIFWError, ConfigurationError, OrchestrationError
 from aifw.schema import LLMResult, RenderedPromptProtocol, ToolCall
 from aifw.service import (
@@ -41,6 +41,7 @@ __all__ = [
     # Constants
     "QualityLevel",
     # Cost estimation
+    "cost_from_rates",
     "estimate_cost",
     # Types
     "ActionConfig",

--- a/src/aifw/cost.py
+++ b/src/aifw/cost.py
@@ -14,18 +14,44 @@ import litellm
 if TYPE_CHECKING:
     from aifw.schema import LLMResult
 
-# Fallback rates: $/1M tokens (input, output)
+# Coarse last-resort fallback rates in $/1M tokens (input, output), keyed by
+# well-known model ids. litellm.cost_per_token() is the source of truth and
+# already covers current models precisely; this table is only consulted when
+# litellm does not recognise the model string. Keep ids real — do not add
+# speculative snapshot ids that litellm would resolve anyway.
+_DEFAULT_RATE: tuple[float, float] = (0.15, 0.60)
 _FALLBACK_RATES: dict[str, tuple[float, float]] = {
     "gpt-4o-mini": (0.15, 0.60),
     "gpt-4o": (2.50, 10.00),
     "gpt-4-turbo": (10.00, 30.00),
     "gpt-3.5-turbo": (0.50, 1.50),
-    "claude-sonnet-4-5-20250514": (3.00, 15.00),
     "claude-3-5-sonnet-20241022": (3.00, 15.00),
     "claude-3-haiku-20240307": (0.25, 1.25),
     "llama-3.3-70b-versatile": (0.59, 0.79),
     "mixtral-8x7b-32768": (0.24, 0.24),
 }
+
+
+def cost_from_rates(
+    input_tokens: int,
+    output_tokens: int,
+    input_rate_per_million: float | Decimal,
+    output_rate_per_million: float | Decimal,
+) -> Decimal:
+    """Compute cost from explicit per-million token rates.
+
+    Single home for the per-million arithmetic — shared by estimate_cost()'s
+    fallback branch and the usage-log path (which uses operator-configured DB
+    rates). Always returns Decimal, never raises.
+    """
+    try:
+        cost = (
+            input_tokens * float(input_rate_per_million) / 1_000_000
+            + output_tokens * float(output_rate_per_million) / 1_000_000
+        )
+        return Decimal(str(round(cost, 8)))
+    except Exception:
+        return Decimal("0")
 
 
 def estimate_cost(
@@ -71,10 +97,6 @@ def estimate_cost(
         pass
 
     # 2. Fallback: built-in rate table
-    try:
-        model_key = model.split("/")[-1]
-        pin, pout = _FALLBACK_RATES.get(model_key, (0.15, 0.60))
-        cost = input_tokens * pin / 1_000_000 + output_tokens * pout / 1_000_000
-        return Decimal(str(round(cost, 8)))
-    except Exception:
-        return Decimal("0")
+    model_key = model.split("/")[-1]
+    pin, pout = _FALLBACK_RATES.get(model_key, _DEFAULT_RATE)
+    return cost_from_rates(input_tokens, output_tokens, pin, pout)

--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -703,11 +703,17 @@ async def _log_usage(
                 tenant_id = None
 
         total_tokens = result.input_tokens + result.output_tokens
+        # Operator-configured DB rates are authoritative for logged cost. When a
+        # model carries no rates this stays 0 and AIUsageLog.save() falls back to
+        # cost.estimate_cost() (litellm / rate table). Single arithmetic helper.
         estimated_cost = 0.0
         if model:
-            estimated_cost = (
-                result.input_tokens / 1_000_000 * float(model.input_cost_per_million)
-                + result.output_tokens / 1_000_000 * float(model.output_cost_per_million)
+            from aifw.cost import cost_from_rates
+            estimated_cost = cost_from_rates(
+                result.input_tokens,
+                result.output_tokens,
+                model.input_cost_per_million,
+                model.output_cost_per_million,
             )
 
         await sync_to_async(AIUsageLog.objects.create)(

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -3,8 +3,36 @@
 from decimal import Decimal
 from unittest.mock import patch
 
-from aifw.cost import estimate_cost
+from aifw.cost import _FALLBACK_RATES, cost_from_rates, estimate_cost
 from aifw.schema import LLMResult
+
+
+class TestCostFromRates:
+    """The single per-million arithmetic helper shared by estimate_cost and
+    the usage-log path."""
+
+    def test_should_compute_from_explicit_rates(self):
+        # 1000 * 3.0/1M + 500 * 15.0/1M = 0.003 + 0.0075 = 0.0105
+        assert cost_from_rates(1000, 500, 3.0, 15.0) == Decimal("0.0105")
+
+    def test_should_return_decimal_for_db_decimal_rates(self):
+        assert cost_from_rates(1000, 1000, Decimal("0.15"), Decimal("0.60")) == Decimal("0.00075")
+
+    def test_should_return_zero_for_zero_rates(self):
+        assert cost_from_rates(1000, 1000, 0, 0) == Decimal("0")
+
+    def test_should_never_raise_on_bad_input(self):
+        assert cost_from_rates(1000, 500, None, None) == Decimal("0")
+
+
+class TestFallbackTableHygiene:
+    def test_should_not_contain_bogus_claude_snapshot_id(self):
+        """The placeholder 'claude-sonnet-4-5-20250514' must stay removed."""
+        assert "claude-sonnet-4-5-20250514" not in _FALLBACK_RATES
+
+    def test_fallback_ids_are_unique_and_real_shaped(self):
+        for key in _FALLBACK_RATES:
+            assert "/" not in key  # bare model id, provider prefix stripped at lookup
 
 
 class TestEstimateCostStandalone:


### PR DESCRIPTION
## Problem (board item #6)

Two issues in cost handling:
1. **Stale fallback table** — `cost._FALLBACK_RATES` contained `claude-sonnet-4-5-20250514`, a made-up snapshot id with an inconsistent format, duplicating `claude-3-5-sonnet`'s rates.
2. **Duplicated arithmetic** — the per-million cost formula lived in two places: `cost.estimate_cost()`'s fallback branch and `service._log_usage()` (which uses operator-configured DB rates). Easy to let them drift.

## Fix

- **Remove the bogus entry.** litellm (`cost_per_token`) is the source of truth and already covers current models precisely; the table is documented as a coarse last-resort fallback for unrecognised model strings. No speculative ids added.
- **`cost.cost_from_rates(input_tokens, output_tokens, input_rate, output_rate)`** is now the single home for the per-million math. Both `estimate_cost()`'s fallback and `_log_usage()` call it. Exported as `aifw.cost_from_rates`.
- `_log_usage()` now produces a `Decimal` (was `float` — better precision into the `DecimalField`). `AIUsageLog.save()` still falls back to `estimate_cost()` (litellm/table) when a model carries no DB rates, so behaviour is unchanged for unpriced models.

## Tests
`tests/test_cost.py` gains `cost_from_rates` cases (explicit rates, Decimal DB rates, zero, never-raises) and table-hygiene assertions (the bogus id stays gone). **144 tests pass**, ruff clean.

## Note
The fallback table is inherently coarse; the authoritative path is litellm for public rates and the operator-configured `LLMModel.input/output_cost_per_million` for logged cost. This PR makes that layering explicit rather than duplicated.

Bumps **0.11.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)