### PR TITLE
feat(privacy): privacy_mode pre-write transform on AIUsageLog (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — aifw
 
+## [0.11.4] — Unreleased
+
+### Added (Privacy-by-Design logging — issue #8)
+- **`AIUsageLog.privacy_mode`** column + `aifw.privacy` pre-write transform. PII is rewritten **before** the row is written, so it never reaches the DB. Three modes, selected via the `AIFW_PRIVACY_MODE` Django setting:
+  - `"full"` — legacy default, `user` FK + `metadata` stored raw (no behavioural change).
+  - `"pseudonymous"` — `user` dropped; `metadata["user_hash"]` = HMAC(user.pk); any `metadata["nl_question"]` replaced by a classified `metadata["topic"]`.
+  - `"anonymous"` — `user` dropped; `metadata` reduced to `{"day_bucket": <ISO date>}` (only `tenant_id` + `action_type` + token counts survive).
+- **Custom hooks** via `AIFW_PRIVACY_HOOK` (dotted path to a `PrivacyHook` instance, subclass, or factory). Topic classification is a plain injected callable — `aifw` never imports `iil-promptfw`. Built-in classifier emits a coarse `"unclassified"` placeholder.
+- **Fail-closed:** if a configured non-`full` hook raises, `user`/`metadata` are scrubbed (`{"privacy_error": True}`) rather than leaking raw PII.
+- **`AIUsageLog.objects.aggregate_with_k_anonymity(*group_by, k=3)`** — k-anonymity aggregation helper; suppresses buckets with fewer than `k` entries.
+- New exports: `aifw.PrivacyMode`, `aifw.PrivacyHook`, `aifw.apply_privacy`, `aifw.get_privacy_hook`.
+- Migration `0009_aiusagelog_privacy_mode` — column defaults to `'full'`, **non-blocking** for existing consumers (no data migration; every pre-existing row keeps legacy semantics).
+
+### Migration note (Consumer-facing)
+- **No breaking change in 0.11.x.** The default is `"full"`, so bfagent / weltenhub / travel-beat audit views that expect a `user` FK + raw `metadata` keep working unchanged.
+- **Default-shift decision:** the default will move to `"pseudonymous"` in **0.12.0** as a documented breaking change — `0.11→0.12` is the upgrade that flips behaviour, not `0.10→0.11`. Consumers relying on raw user logging must then set `AIFW_PRIVACY_MODE = "full"` explicitly.
+
+### Fixed
+- Removed an unused `from aifw.schema import LLMResult` import in `tests/test_service.py::FakeStack` that slipped past the ruff CI gate.
+
 ## [0.11.2] — 2026-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -111,6 +111,66 @@ result = sync_completion(
 )
 ```
 
+### Privacy-by-Design Logging (issue #8)
+
+`AIUsageLog` can pseudonymise or anonymise itself **at write time** — PII never
+reaches the database. Select the policy with one Django setting (DSGVO Art. 25 /
+Art. 5 Abs. 1 lit. c):
+
+```python
+# settings.py
+from aifw.constants import PrivacyMode
+AIFW_PRIVACY_MODE = PrivacyMode.PSEUDONYMOUS   # "full" (default) | "pseudonymous" | "anonymous"
+AIFW_PRIVACY_HMAC_SECRET = env("AIFW_PRIVACY_HMAC_SECRET")  # optional; falls back to SECRET_KEY
+```
+
+```python
+# Call site stays the same — the hook transforms the row before it is written:
+sync_completion(
+    "nl2sql", messages,
+    user=request.user,
+    tenant_id=user.organization_id,
+    metadata={"nl_question": question},
+)
+```
+
+| Mode | `user` | `metadata` |
+|---|---|---|
+| `full` *(default)* | stored raw (FK) | stored raw |
+| `pseudonymous` | `NULL` | `user_hash` = HMAC(user.pk); `nl_question` → `topic` |
+| `anonymous` | `NULL` | reduced to `{"day_bucket": "<ISO date>"}` (tenant + tokens survive) |
+
+The `privacy_mode` column records which policy was applied to each row.
+
+**Topic classification** is a plain callable — `aifw` never imports `iil-promptfw`.
+The built-in pseudonymous classifier emits a coarse placeholder (`"unclassified"`);
+wire a real classifier via a **custom hook**:
+
+```python
+# myapp/privacy.py
+from aifw.privacy import PseudonymousHook
+
+def my_hook():
+    from promptfw import classify_topic
+    return PseudonymousHook(topic_classifier=classify_topic)
+
+# settings.py
+AIFW_PRIVACY_HOOK = "myapp.privacy:my_hook"   # dotted path → PrivacyHook / subclass / factory
+```
+
+A custom hook receives the create-payload dict (keys: `user`, `tenant_id`,
+`metadata`, …) and returns it rewritten. If a configured non-`full` hook raises,
+logging **fails closed** — `user`/`metadata` are scrubbed rather than leaking PII.
+
+For supervisor-facing reports, `AIUsageLog.objects.aggregate_with_k_anonymity(
+*group_by, k=3)` returns only buckets with ≥ k entries (suppresses re-identifiable
+small groups).
+
+> **Default-shift roadmap:** the default stays `"full"` in the 0.11.x line to keep
+> existing audit views (bfagent, weltenhub, travel-beat) working unchanged. A shift
+> to `"pseudonymous"` as the default is planned for **0.12.0** as a documented
+> breaking change.
+
 ### Streaming (v0.4.0)
 
 ```python
@@ -131,7 +191,7 @@ def stream_story(request):
 | `LLMProvider` | Provider config (API key env var, base URL) |
 | `LLMModel` | Model config (max tokens, cost per million tokens) |
 | `AIActionType` | Action → model mapping; supports `quality_level` + `priority` dimensions |
-| `AIUsageLog` | Token/latency/cost tracking per request, with `tenant_id` + `metadata` |
+| `AIUsageLog` | Token/latency/cost tracking per request, with `tenant_id` + `metadata` + `privacy_mode` |
 | `TierQualityMapping` | Subscription tier → quality_level mapping (DB-driven) |
 
 ## NL2SQL (v0.7.0+)
@@ -225,6 +285,12 @@ python manage.py init_aifw_config
 |---|---|---|
 | `AIFW_LOCAL_CACHE_TTL` | `30` | Process-local cache TTL in seconds |
 | `AIFW_CACHE_TTL` | `600` | Shared cache TTL in seconds (Redis-backed) |
+| `AIFW_PRIVACY_MODE` | `full` | Privacy policy for AIUsageLog: `full` \| `pseudonymous` \| `anonymous` (issue #8) |
+| `AIFW_PRIVACY_HOOK` | — | Dotted path to a custom `PrivacyHook` (overrides `AIFW_PRIVACY_MODE`) |
+| `AIFW_PRIVACY_HMAC_SECRET` | `SECRET_KEY` | HMAC key for pseudonymous `user_hash` |
+
+> `AIFW_PRIVACY_*` are read from **Django settings** (not env), like Django's own
+> `SECRET_KEY`. The cache TTLs above are read from the process environment.
 
 No Django settings dict is required — all configuration is managed via Django Admin models.
 

--- a/src/aifw/__init__.py
+++ b/src/aifw/__init__.py
@@ -15,9 +15,10 @@ New in 0.6.0:
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
-from aifw.constants import QualityLevel
+from aifw.constants import PrivacyMode, QualityLevel
 from aifw.cost import cost_from_rates, estimate_cost
 from aifw.exceptions import AIFWError, ConfigurationError, OrchestrationError
+from aifw.privacy import PrivacyHook, apply_privacy, get_privacy_hook
 from aifw.schema import LLMResult, RenderedPromptProtocol, ToolCall
 from aifw.service import (
     check_action_code,
@@ -40,6 +41,11 @@ __all__ = [
     "__version__",
     # Constants
     "QualityLevel",
+    "PrivacyMode",
+    # Privacy (issue #8)
+    "PrivacyHook",
+    "apply_privacy",
+    "get_privacy_hook",
     # Cost estimation
     "cost_from_rates",
     "estimate_cost",

--- a/src/aifw/admin.py
+++ b/src/aifw/admin.py
@@ -36,12 +36,12 @@ class TierQualityMappingAdmin(admin.ModelAdmin):
 @admin.register(AIUsageLog)
 class AIUsageLogAdmin(admin.ModelAdmin):
     list_display = [
-        "action_type", "model_used", "quality_level", "user",
+        "action_type", "model_used", "quality_level", "privacy_mode", "user",
         "total_tokens", "estimated_cost", "latency_ms", "success", "created_at",
     ]
-    list_filter = ["success", "quality_level", "action_type", "model_used"]
+    list_filter = ["success", "privacy_mode", "quality_level", "action_type", "model_used"]
     readonly_fields = [
-        "action_type", "model_used", "user", "quality_level",
+        "action_type", "model_used", "user", "quality_level", "privacy_mode",
         "input_tokens", "output_tokens", "total_tokens",
         "estimated_cost", "latency_ms", "success",
         "error_message", "created_at",

--- a/src/aifw/constants.py
+++ b/src/aifw/constants.py
@@ -42,3 +42,31 @@ class QualityLevel:
 
 #: Valid priority string values (NULL = catch-all, handled separately)
 VALID_PRIORITIES: frozenset[str] = frozenset({"fast", "balanced", "quality"})
+
+
+class PrivacyMode:
+    """Privacy policy applied to an AIUsageLog row at write time (issue #8).
+
+    Consumers select the active mode via the ``AIFW_PRIVACY_MODE`` Django
+    setting and use symbolic names rather than raw strings::
+
+        from aifw.constants import PrivacyMode
+        # settings.py
+        AIFW_PRIVACY_MODE = PrivacyMode.PSEUDONYMOUS
+    """
+
+    FULL: str = "full"                  # legacy default — user + metadata raw
+    PSEUDONYMOUS: str = "pseudonymous"  # HMAC user_hash + classified topic
+    ANONYMOUS: str = "anonymous"        # tenant + tokens + day_bucket only
+
+    #: All valid mode strings
+    ALL: tuple[str, ...] = (FULL, PSEUDONYMOUS, ANONYMOUS)
+
+    @classmethod
+    def is_valid(cls, value: str | None) -> bool:
+        """Return True if value is a valid privacy mode."""
+        return value in cls.ALL
+
+
+#: Valid privacy mode strings
+VALID_PRIVACY_MODES: frozenset[str] = frozenset(PrivacyMode.ALL)

--- a/src/aifw/migrations/0009_aiusagelog_privacy_mode.py
+++ b/src/aifw/migrations/0009_aiusagelog_privacy_mode.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Add AIUsageLog.privacy_mode (issue #8).
+
+    Non-blocking for existing consumers: column defaults to 'full', so every
+    pre-existing row keeps legacy raw-logging semantics with no data migration.
+    """
+
+    # NB: the real leaf of the aifw graph is 0007 (it depends on 0008, the
+    # numbering is non-linear after the nl2sql app_label move). Depend on the
+    # leaf, not the higher number, to avoid a multi-leaf conflict.
+    dependencies = [
+        ("aifw", "0007_nl2sql_app_label"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="aiusagelog",
+            name="privacy_mode",
+            field=models.CharField(
+                db_index=True,
+                default="full",
+                help_text=(
+                    "Privacy policy applied at write time: "
+                    "'full' (raw) | 'pseudonymous' (HMAC user_hash + topic) | "
+                    "'anonymous' (tenant + day_bucket only)."
+                ),
+                max_length=16,
+            ),
+        ),
+    ]

--- a/src/aifw/models.py
+++ b/src/aifw/models.py
@@ -283,11 +283,44 @@ class TierQualityMapping(models.Model):
         return f"{self.tier} → ql={self.quality_level}"
 
 
+class AIUsageLogQuerySet(models.QuerySet):
+    """Custom queryset with a k-anonymity aggregation helper (issue #8)."""
+
+    def aggregate_with_k_anonymity(
+        self, *group_by: str, k: int = 3
+    ) -> "models.QuerySet":
+        """Group by the given fields, returning only buckets with ≥ k entries.
+
+        Useful for supervisor-facing usage views without re-identification risk:
+        any group smaller than ``k`` is suppressed entirely. Each surviving row
+        carries ``entry_count``, ``total_tokens`` and ``total_cost``.
+
+        Example::
+
+            AIUsageLog.objects.aggregate_with_k_anonymity(
+                "action_type", "quality_level", k=5
+            )
+        """
+        from django.db.models import Count, Sum
+
+        return (
+            self.values(*group_by)
+            .annotate(
+                entry_count=Count("id"),
+                total_tokens=Sum("total_tokens"),
+                total_cost=Sum("estimated_cost"),
+            )
+            .filter(entry_count__gte=k)
+        )
+
+
 class AIUsageLog(models.Model):
     """Token & cost tracking per LLM request.
 
     New in 0.6.0: quality_level column for direct cost-per-tier analytics
     without joins (ADR-095 OQ-2).
+    New in 0.11.x: privacy_mode column records the privacy policy applied at
+    write time (issue #8). See aifw.privacy for the pre-write transform.
     """
 
     action_type = models.ForeignKey(
@@ -319,6 +352,17 @@ class AIUsageLog(models.Model):
         blank=True,
         help_text="Arbitrary key/value context (pipeline stage, prompt version, etc.).",
     )
+    privacy_mode = models.CharField(
+        max_length=16,
+        default="full",
+        db_index=True,
+        help_text=(
+            "Privacy policy applied at write time (issue #8): "
+            "'full' (raw) | 'pseudonymous' (HMAC user_hash + topic) | "
+            "'anonymous' (tenant + day_bucket only). "
+            "Set automatically by aifw.privacy from AIFW_PRIVACY_MODE."
+        ),
+    )
     # ── NEW in 0.6.0 ───────────────────────────────────────────────────────────────
     quality_level = models.IntegerField(
         null=True,
@@ -339,6 +383,8 @@ class AIUsageLog(models.Model):
     success = models.BooleanField(default=True)
     error_message = models.TextField(blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
+
+    objects = AIUsageLogQuerySet.as_manager()
 
     class Meta:
         app_label = "aifw"

--- a/src/aifw/privacy.py
+++ b/src/aifw/privacy.py
@@ -1,0 +1,214 @@
+"""
+Privacy-by-Design pre-write transforms for AIUsageLog (ADR-003 ttz-hub, issue #8).
+
+A *privacy hook* rewrites the AIUsageLog create-payload **before** it is written,
+so PII never reaches the database in the first place (DSGVO Art. 25 / Art. 5 Abs.
+1 lit. c — Privacy-by-Design + Datenminimierung).
+
+Three built-in modes (selected via the ``AIFW_PRIVACY_MODE`` Django setting):
+
+- ``"full"``         — legacy default: ``user`` + ``metadata`` written raw, as before.
+- ``"pseudonymous"`` — ``user`` dropped; ``metadata["user_hash"]`` = HMAC(user.pk);
+                       any ``metadata["nl_question"]`` is replaced by ``metadata["topic"]``
+                       via a topic classifier (default: a coarse placeholder — wire
+                       ``iil-promptfw`` or any callable via a custom hook for real topics).
+- ``"anonymous"``    — ``user`` dropped; ``metadata`` reduced to ``{"day_bucket": <ISO date>}``.
+                       Only ``tenant_id`` + ``action_type`` + token counts survive.
+
+Custom hooks are registered via the ``AIFW_PRIVACY_HOOK`` setting, a dotted path
+in either ``"module.path:attr"`` or ``"module.path.attr"`` form. The target may be
+a :class:`PrivacyHook` instance, a :class:`PrivacyHook` subclass, or a zero-arg
+factory returning one.
+
+**Fail-closed.** If a configured non-``full`` hook raises, the payload is scrubbed
+(``user=None``, ``metadata={"privacy_error": True}``) rather than leaking raw PII.
+
+The ``AIFW_PRIVACY_HMAC_SECRET`` setting keys the pseudonymous user hash; it falls
+back to Django's ``SECRET_KEY`` when unset. ``aifw`` never imports ``iil-promptfw`` —
+topic classification is a plain callable injected by the consumer.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import importlib
+import logging
+from typing import Any, Callable
+
+from aifw.constants import PrivacyMode
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Settings access (read fresh every call — override_settings must take effect)
+# ---------------------------------------------------------------------------
+
+def _get_setting(name: str, default: Any = None) -> Any:
+    from django.conf import settings
+    return getattr(settings, name, default)
+
+
+def _resolve_hmac_secret() -> bytes:
+    secret = _get_setting("AIFW_PRIVACY_HMAC_SECRET") or _get_setting("SECRET_KEY", "")
+    return str(secret).encode("utf-8")
+
+
+def _hmac_user(user_pk: Any, secret: bytes) -> str:
+    return hmac.new(secret, str(user_pk).encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _today_iso() -> str:
+    from django.utils import timezone
+    return timezone.now().date().isoformat()
+
+
+def _default_topic_classifier(nl_question: str) -> str:
+    """Built-in placeholder classifier.
+
+    aifw ships no NLP. This guarantees the raw question never persists by
+    replacing it with a coarse marker. Consumers wire a real classifier
+    (e.g. iil-promptfw) via a custom hook for meaningful topics.
+    """
+    return "unclassified"
+
+
+# ---------------------------------------------------------------------------
+# Hook implementations
+# ---------------------------------------------------------------------------
+
+class PrivacyHook:
+    """Base hook — ``full`` mode: identity transform (writes payload raw)."""
+
+    mode: str = PrivacyMode.FULL
+
+    def transform(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Rewrite the AIUsageLog create-payload in place and return it.
+
+        Payload keys of interest: ``user`` (User instance or None), ``tenant_id``,
+        ``metadata`` (dict). Other keys (tokens, action_type, ...) pass through.
+        """
+        return payload
+
+
+class PseudonymousHook(PrivacyHook):
+    """Drop the user FK, replace it with an HMAC hash, classify the question."""
+
+    mode = PrivacyMode.PSEUDONYMOUS
+
+    def __init__(
+        self,
+        hmac_secret: bytes | None = None,
+        topic_classifier: Callable[[str], str] | None = None,
+    ) -> None:
+        self._secret = hmac_secret if hmac_secret is not None else _resolve_hmac_secret()
+        self._classify = topic_classifier or _default_topic_classifier
+
+    def transform(self, payload: dict[str, Any]) -> dict[str, Any]:
+        user = payload.get("user")
+        user_pk = getattr(user, "pk", None)
+        payload["user"] = None
+        meta = dict(payload.get("metadata") or {})
+        if user_pk is not None:
+            meta["user_hash"] = _hmac_user(user_pk, self._secret)
+        if "nl_question" in meta:
+            meta["topic"] = self._classify(meta.pop("nl_question"))
+        payload["metadata"] = meta
+        return payload
+
+
+class AnonymousHook(PrivacyHook):
+    """Strip every user trace — keep only tenant/action/tokens + a day bucket."""
+
+    mode = PrivacyMode.ANONYMOUS
+
+    def transform(self, payload: dict[str, Any]) -> dict[str, Any]:
+        payload["user"] = None
+        payload["metadata"] = {"day_bucket": _today_iso()}
+        return payload
+
+
+_BUILTIN_HOOKS: dict[str, type[PrivacyHook]] = {
+    PrivacyMode.FULL: PrivacyHook,
+    PrivacyMode.PSEUDONYMOUS: PseudonymousHook,
+    PrivacyMode.ANONYMOUS: AnonymousHook,
+}
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+def _import_hook(dotted: str) -> PrivacyHook:
+    """Import a custom hook from ``"module:attr"`` or ``"module.attr"``."""
+    if ":" in dotted:
+        module_path, attr = dotted.split(":", 1)
+    else:
+        module_path, attr = dotted.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    obj = getattr(module, attr)
+    if isinstance(obj, PrivacyHook):
+        return obj
+    if isinstance(obj, type) and issubclass(obj, PrivacyHook):
+        return obj()
+    if callable(obj):
+        result = obj()
+        if isinstance(result, PrivacyHook):
+            return result
+        raise TypeError(
+            f"AIFW_PRIVACY_HOOK {dotted!r} factory returned {type(result).__name__}, "
+            f"expected a PrivacyHook"
+        )
+    raise TypeError(
+        f"AIFW_PRIVACY_HOOK {dotted!r} is neither a PrivacyHook, subclass, nor factory"
+    )
+
+
+def get_privacy_hook() -> PrivacyHook:
+    """Resolve the active privacy hook from Django settings.
+
+    Priority: ``AIFW_PRIVACY_HOOK`` (custom dotted path) → ``AIFW_PRIVACY_MODE``
+    (built-in mode, default ``"full"``). An invalid mode logs a warning and
+    falls back to ``"full"``.
+    """
+    dotted = _get_setting("AIFW_PRIVACY_HOOK")
+    if dotted:
+        return _import_hook(dotted)
+
+    mode = _get_setting("AIFW_PRIVACY_MODE", PrivacyMode.FULL)
+    if not PrivacyMode.is_valid(mode):
+        logger.warning(
+            "Invalid AIFW_PRIVACY_MODE %r — falling back to 'full'", mode
+        )
+        mode = PrivacyMode.FULL
+    return _BUILTIN_HOOKS[mode]()
+
+
+def apply_privacy(payload: dict[str, Any]) -> dict[str, Any]:
+    """Run the active privacy hook over an AIUsageLog create-payload.
+
+    Always stamps ``payload["privacy_mode"]`` with the applied mode. Fail-closed:
+    if a configured non-``full`` hook raises, the user/metadata are scrubbed so a
+    broken transform can never leak PII.
+    """
+    try:
+        hook = get_privacy_hook()
+        payload = hook.transform(payload)
+        payload["privacy_mode"] = getattr(hook, "mode", PrivacyMode.FULL)
+        return payload
+    except Exception as exc:  # noqa: BLE001 — privacy must never crash logging
+        intended = _get_setting("AIFW_PRIVACY_MODE", PrivacyMode.FULL)
+        custom = bool(_get_setting("AIFW_PRIVACY_HOOK"))
+        if custom or intended != PrivacyMode.FULL:
+            logger.warning(
+                "Privacy hook failed (%s) — failing closed, scrubbing PII", exc
+            )
+            payload["user"] = None
+            payload["metadata"] = {"privacy_error": True}
+            payload["privacy_mode"] = (
+                intended if PrivacyMode.is_valid(intended) else PrivacyMode.ANONYMOUS
+            )
+        else:
+            logger.warning("Privacy hook failed (%s) — writing 'full' raw log", exc)
+            payload["privacy_mode"] = PrivacyMode.FULL
+        return payload

--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -718,22 +718,32 @@ async def _log_usage(
                 model.output_cost_per_million,
             )
 
-        await sync_to_async(AIUsageLog.objects.create)(
-            action_type=action,
-            model_used=model,
-            user=user,
-            tenant_id=tenant_id,
-            object_id=object_id or "",
-            metadata=metadata or {},
-            quality_level=quality_level,
-            input_tokens=result.input_tokens,
-            output_tokens=result.output_tokens,
-            total_tokens=total_tokens,
-            estimated_cost=estimated_cost,
-            latency_ms=result.latency_ms,
-            success=result.success,
-            error_message=result.error or "",
+        # Privacy-by-Design (issue #8): the configured hook rewrites the payload
+        # before it is written, so PII (user FK, raw nl_question) never reaches
+        # the DB when AIFW_PRIVACY_MODE is pseudonymous/anonymous. Default 'full'
+        # is an identity transform — zero behavioural change for legacy consumers.
+        from aifw.privacy import apply_privacy
+
+        payload = apply_privacy(
+            {
+                "action_type": action,
+                "model_used": model,
+                "user": user,
+                "tenant_id": tenant_id,
+                "object_id": object_id or "",
+                "metadata": metadata or {},
+                "quality_level": quality_level,
+                "input_tokens": result.input_tokens,
+                "output_tokens": result.output_tokens,
+                "total_tokens": total_tokens,
+                "estimated_cost": estimated_cost,
+                "latency_ms": result.latency_ms,
+                "success": result.success,
+                "error_message": result.error or "",
+            }
         )
+
+        await sync_to_async(AIUsageLog.objects.create)(**payload)
     except Exception as exc:
         logger.warning("Failed to log usage: %s", exc)
 

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,299 @@
+"""
+Tests for privacy_mode pre-write transforms (issue #8).
+
+Covers the three built-in modes end-to-end through _log_usage (the real DB write
+path), the custom-hook registration mechanism, fail-closed behaviour, and the
+k-anonymity aggregation helper.
+"""
+
+import uuid
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+
+from aifw.constants import PrivacyMode
+from aifw.models import AIActionType, AIUsageLog, LLMModel, LLMProvider
+from aifw.privacy import (
+    AnonymousHook,
+    PrivacyHook,
+    PseudonymousHook,
+    apply_privacy,
+    get_privacy_hook,
+)
+from aifw.schema import LLMResult
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def provider(db):
+    return LLMProvider.objects.create(
+        name="openai", display_name="OpenAI", api_key_env_var="OPENAI_API_KEY"
+    )
+
+
+@pytest.fixture
+def model(provider):
+    return LLMModel.objects.create(
+        provider=provider,
+        name="gpt-4o-mini",
+        display_name="GPT-4o Mini",
+        input_cost_per_million=0.15,
+        output_cost_per_million=0.60,
+        is_default=True,
+    )
+
+
+@pytest.fixture
+def action(model):
+    return AIActionType.objects.create(
+        code="nl2sql", name="NL2SQL", default_model=model, max_tokens=1000
+    )
+
+
+@pytest.fixture
+def config(action, model, provider):
+    return {
+        "model_string": "gpt-4o-mini",
+        "api_key": "sk-test",
+        "api_base": None,
+        "max_tokens": 1000,
+        "temperature": 0.5,
+        "action_id": action.id,
+        "model_id": model.id,
+        "provider_name": provider.name,
+        "model_name": model.name,
+    }
+
+
+@pytest.fixture
+def result():
+    return LLMResult(
+        success=True, content="ok", model="gpt-4o-mini",
+        input_tokens=100, output_tokens=50, latency_ms=200,
+    )
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create(username="alice")
+
+
+# ---------------------------------------------------------------------------
+# Constants / resolution
+# ---------------------------------------------------------------------------
+
+def test_should_validate_known_privacy_modes():
+    assert PrivacyMode.is_valid("full")
+    assert PrivacyMode.is_valid("pseudonymous")
+    assert PrivacyMode.is_valid("anonymous")
+    assert not PrivacyMode.is_valid("bogus")
+    assert not PrivacyMode.is_valid(None)
+
+
+def test_should_default_to_full_hook_when_unset(settings):
+    # No AIFW_PRIVACY_MODE configured → full (identity) hook.
+    hook = get_privacy_hook()
+    assert hook.mode == PrivacyMode.FULL
+    assert isinstance(hook, PrivacyHook)
+
+
+@override_settings(AIFW_PRIVACY_MODE="pseudonymous")
+def test_should_resolve_pseudonymous_hook():
+    assert isinstance(get_privacy_hook(), PseudonymousHook)
+
+
+@override_settings(AIFW_PRIVACY_MODE="anonymous")
+def test_should_resolve_anonymous_hook():
+    assert isinstance(get_privacy_hook(), AnonymousHook)
+
+
+@override_settings(AIFW_PRIVACY_MODE="garbage")
+def test_should_fall_back_to_full_on_invalid_mode():
+    assert get_privacy_hook().mode == PrivacyMode.FULL
+
+
+# ---------------------------------------------------------------------------
+# apply_privacy() — unit level
+# ---------------------------------------------------------------------------
+
+@override_settings(AIFW_PRIVACY_MODE="full")
+def test_should_pass_payload_through_unchanged_in_full_mode(user):
+    payload = apply_privacy(
+        {"user": user, "metadata": {"nl_question": "how many orders?"}}
+    )
+    assert payload["user"] is user
+    assert payload["metadata"]["nl_question"] == "how many orders?"
+    assert payload["privacy_mode"] == "full"
+
+
+@override_settings(AIFW_PRIVACY_MODE="pseudonymous", AIFW_PRIVACY_HMAC_SECRET="s3cr3t")
+def test_should_pseudonymise_user_and_classify_question(user):
+    payload = apply_privacy(
+        {"user": user, "metadata": {"nl_question": "how many orders?"}}
+    )
+    assert payload["user"] is None
+    assert "nl_question" not in payload["metadata"]
+    assert payload["metadata"]["topic"] == "unclassified"
+    assert len(payload["metadata"]["user_hash"]) == 64  # sha256 hexdigest
+    assert payload["privacy_mode"] == "pseudonymous"
+
+
+@override_settings(AIFW_PRIVACY_MODE="pseudonymous", AIFW_PRIVACY_HMAC_SECRET="s3cr3t")
+def test_should_produce_stable_user_hash(user):
+    h1 = apply_privacy({"user": user, "metadata": {}})["metadata"]["user_hash"]
+    h2 = apply_privacy({"user": user, "metadata": {}})["metadata"]["user_hash"]
+    assert h1 == h2
+
+
+@override_settings(AIFW_PRIVACY_MODE="anonymous")
+def test_should_strip_all_user_trace_in_anonymous_mode(user):
+    payload = apply_privacy(
+        {"user": user, "metadata": {"nl_question": "secret", "extra": 1}}
+    )
+    assert payload["user"] is None
+    assert list(payload["metadata"].keys()) == ["day_bucket"]
+    assert payload["privacy_mode"] == "anonymous"
+
+
+# ---------------------------------------------------------------------------
+# Custom hook registration
+# ---------------------------------------------------------------------------
+
+class _ShoutHook(PrivacyHook):
+    mode = "pseudonymous"
+
+    def transform(self, payload):
+        payload["user"] = None
+        payload["metadata"] = {"custom": "applied"}
+        return payload
+
+
+_shout_instance = _ShoutHook()
+
+
+@override_settings(AIFW_PRIVACY_HOOK="tests.test_privacy:_ShoutHook")
+def test_should_load_custom_hook_class_by_dotted_path(user):
+    payload = apply_privacy({"user": user, "metadata": {"nl_question": "x"}})
+    assert payload["metadata"] == {"custom": "applied"}
+    assert payload["user"] is None
+
+
+@override_settings(AIFW_PRIVACY_HOOK="tests.test_privacy:_shout_instance")
+def test_should_load_custom_hook_instance_by_dotted_path(user):
+    payload = apply_privacy({"user": user, "metadata": {}})
+    assert payload["metadata"] == {"custom": "applied"}
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed
+# ---------------------------------------------------------------------------
+
+class _BrokenHook(PrivacyHook):
+    mode = "pseudonymous"
+
+    def transform(self, payload):
+        raise RuntimeError("classifier exploded")
+
+
+@override_settings(
+    AIFW_PRIVACY_HOOK="tests.test_privacy:_BrokenHook",
+    AIFW_PRIVACY_MODE="pseudonymous",
+)
+def test_should_fail_closed_and_scrub_pii_when_hook_raises(user):
+    payload = apply_privacy(
+        {"user": user, "metadata": {"nl_question": "leak me"}}
+    )
+    assert payload["user"] is None
+    assert payload["metadata"] == {"privacy_error": True}
+    assert payload["privacy_mode"] == "pseudonymous"
+
+
+# ---------------------------------------------------------------------------
+# E2E through _log_usage (real DB write)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+@override_settings(AIFW_PRIVACY_MODE="pseudonymous", AIFW_PRIVACY_HMAC_SECRET="k")
+async def test_should_write_pseudonymous_row(config, result, user):
+    from aifw.service import _log_usage
+
+    await _log_usage(
+        config, result, user=user,
+        metadata={"nl_question": "how many late orders?"},
+    )
+
+    log = await AIUsageLog.objects.alatest("created_at")
+    assert log.user_id is None
+    assert log.privacy_mode == "pseudonymous"
+    assert "nl_question" not in log.metadata
+    assert log.metadata["topic"] == "unclassified"
+    assert log.metadata["user_hash"]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+@override_settings(AIFW_PRIVACY_MODE="anonymous")
+async def test_should_write_anonymous_row(config, result, user):
+    from aifw.service import _log_usage
+
+    tenant = uuid.uuid4()
+    await _log_usage(
+        config, result, user=user, tenant_id=tenant,
+        metadata={"nl_question": "secret"},
+    )
+
+    log = await AIUsageLog.objects.alatest("created_at")
+    assert log.user_id is None
+    assert log.privacy_mode == "anonymous"
+    assert log.tenant_id == tenant  # tenant survives anonymisation
+    assert log.total_tokens == 150  # token counts survive
+    assert list(log.metadata.keys()) == ["day_bucket"]
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_should_default_to_full_raw_row(config, result, user):
+    from aifw.service import _log_usage
+
+    await _log_usage(
+        config, result, user=user,
+        metadata={"nl_question": "how many orders?"},
+    )
+
+    log = await AIUsageLog.objects.alatest("created_at")
+    assert log.user_id == user.id
+    assert log.privacy_mode == "full"
+    assert log.metadata["nl_question"] == "how many orders?"
+
+
+# ---------------------------------------------------------------------------
+# k-anonymity helper
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_should_suppress_buckets_below_k(action, model):
+    # 3 rows for ql=5, 1 row for ql=8 → with k=3 only the ql=5 bucket survives.
+    for _ in range(3):
+        AIUsageLog.objects.create(
+            action_type=action, model_used=model, quality_level=5,
+            input_tokens=10, output_tokens=5,
+        )
+    AIUsageLog.objects.create(
+        action_type=action, model_used=model, quality_level=8,
+        input_tokens=10, output_tokens=5,
+    )
+
+    buckets = list(
+        AIUsageLog.objects.aggregate_with_k_anonymity("quality_level", k=3)
+    )
+    assert len(buckets) == 1
+    assert buckets[0]["quality_level"] == 5
+    assert buckets[0]["entry_count"] == 3
+    assert buckets[0]["total_tokens"] == 45

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -473,7 +473,6 @@ async def test_should_accept_stack_patterns_context_instead_of_messages():
 
     class FakeStack:
         def render_stack(self, patterns, context):
-            from aifw.schema import LLMResult
             # Return a duck-typed RenderedPrompt
             class R:
                 system = f"system:{context.get('topic','')}"


### PR DESCRIPTION
Closes #8.

## What

Privacy-by-Design audit logging for `AIUsageLog` (DSGVO Art. 25 / Art. 5 Abs. 1 lit. c). A pre-write hook rewrites the log payload **before** it hits the DB, so PII never lands raw.

### Modes (`AIFW_PRIVACY_MODE` Django setting)
| Mode | `user` | `metadata` |
|---|---|---|
| `full` *(default)* | raw FK | raw |
| `pseudonymous` | `NULL` | `user_hash`=HMAC(user.pk); `nl_question`→`topic` |
| `anonymous` | `NULL` | `{"day_bucket": <ISO>}` (tenant + tokens survive) |

### Highlights
- `AIUsageLog.privacy_mode` column + migration `0009` — default `'full'`, **non-blocking** (no data migration; existing rows keep legacy semantics).
- `aifw.privacy`: `PrivacyHook` / `PseudonymousHook` / `AnonymousHook`; custom hooks via `AIFW_PRIVACY_HOOK` dotted path (instance / subclass / factory).
- Topic classification is an injected callable — **aifw never imports `iil-promptfw`**. Built-in default emits `"unclassified"`.
- **Fail-closed**: a raising non-`full` hook scrubs `user`/`metadata` instead of leaking PII.
- `AIUsageLog.objects.aggregate_with_k_anonymity(*group_by, k=3)` helper.
- Exports: `PrivacyMode`, `PrivacyHook`, `apply_privacy`, `get_privacy_hook`.

### Default-shift decision
Default stays `"full"` in 0.11.x (keeps bfagent/weltenhub/travel-beat working). Shift to `"pseudonymous"` planned for **0.12.0** as a documented breaking change. Recorded in CHANGELOG + README.

## Tests
16 new tests (3 modes E2E via `_log_usage`, custom-hook load, fail-closed, k-anon). Full suite: **162 passed**, ruff clean.

## Drive-by
Removed an unused `from aifw.schema import LLMResult` in `tests/test_service.py::FakeStack` that slipped past the ruff CI gate (introduced in 422e1a2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)