### PR TITLE
chore(release): bump version to 0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog — aifw
 
-## [0.11.4] — Unreleased
+## [0.11.4] — 2026-06-15
 
 ### Added (Privacy-by-Design logging — issue #8)
 - **`AIUsageLog.privacy_mode`** column + `aifw.privacy` pre-write transform. PII is rewritten **before** the row is written, so it never reaches the DB. Three modes, selected via the `AIFW_PRIVACY_MODE` Django setting:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iil-aifw"
-version = "0.11.3"
+version = "0.11.4"
 description = "Django AI Services Framework — DB-driven LLM routing, quality tiers, NL2SQL"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Release 0.11.4 — Privacy-by-Design logging (`privacy_mode`, #8 / #19).

- Bump `pyproject.toml` 0.11.3 → 0.11.4
- Date CHANGELOG `[0.11.4]` section (2026-06-15)

Default stays `"full"` → no breaking change for consumers. After merge: tag `v0.11.4` + PyPI publish via `publish-package.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)