### PR TITLE
chore(agent-readiness): CLAUDE.md + AGENT_HANDOVER + config alignment

### DIFF
--- a/AGENT_HANDOVER.md
+++ b/AGENT_HANDOVER.md
@@ -1,0 +1,53 @@
+# AGENT_HANDOVER.md — iil-aifw
+
+Living handover for the next agent (or human). For repo operating details see
+`CLAUDE.md`; for the change log see `CHANGELOG.md`. **NEXT.md is an auto-generated
+editor cache, not the source of truth — do not rely on it.**
+
+## Current state (observed 2026-06-22)
+
+- **Version:** `0.11.4` (pyproject `version`; `__version__` resolves from installed
+  package metadata).
+- **Tests:** `make test` → **162 passed** (1 cosmetic pytest naming-convention warning).
+  In-memory SQLite, no external services required.
+- **Lint:** `make lint` (ruff `E,F,I`, line-length 100, `target-version py312`) →
+  **clean**, all checks pass.
+- **Types:** no mypy gate configured (package ships `py.typed` for consumers).
+- **CI:** `.github/workflows/ci.yml` runs ruff + `pytest -v` on Python 3.12 for
+  push/PR to `main`. Publishing is a separate **gated** workflow (`publish.yml`),
+  not on-merge.
+
+## Recently landed
+
+- **0.11.x — Privacy-by-design logging (issue #8):** `AIUsageLog.privacy_mode`
+  column + `aifw.privacy` pre-write transform (`full`/`pseudonymous`/`anonymous`),
+  custom hooks via `AIFW_PRIVACY_HOOK`, fail-closed scrubbing, k-anonymity
+  aggregation. Default stays `"full"` (non-breaking).
+- **0.10.x — Quality-level routing:** `get_action_config`,
+  `get_quality_level_for_tier`, DB-driven tier→quality mapping.
+- **0.7.0+ — NL2SQL subsystem** under `aifw.nl2sql` (optional app).
+
+## Known issues / TODO
+
+- Pre-existing pytest naming-convention warnings (`test_should_<...>` preferred) on
+  several tests — cosmetic, deferred.
+- No mypy/type-check gate yet (deferred to a later agent-readiness tier).
+- **Planned breaking change:** default `AIFW_PRIVACY_MODE` moves `"full"` →
+  `"pseudonymous"` in **0.12.0** (documented). Consumers relying on raw user logging
+  must then set `AIFW_PRIVACY_MODE = "full"` explicitly.
+
+## Next priorities
+
+1. 0.12.0 privacy-default flip + consumer migration notes (bfagent, weltenhub,
+   travel-beat).
+2. Optional: add a mypy gate (next agent-readiness tier).
+3. Tidy up legacy test names to the `test_should_*` convention.
+
+## Pointers
+
+- Operating guide & module map: `CLAUDE.md`
+- Public API surface + version logic: `src/aifw/__init__.py`
+- Core entrypoints: `src/aifw/service.py`
+- Privacy model: `src/aifw/privacy.py`, `src/aifw/constants.py`
+- NL2SQL: `src/aifw/nl2sql/`
+- Change history: `CHANGELOG.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md — iil-aifw operating guide
+
+## What this is
+
+`iil-aifw` (import package `aifw`) is a **Django AI Services Framework**: DB-driven
+LLM provider/model/usage management, quality-tier routing, privacy-by-design usage
+logging, and an optional NL2SQL (text-to-SQL) subsystem. It is a reusable library
+published to PyPI as `iil-aifw` and consumed by platform apps (bfagent, weltenhub,
+travel-beat, …). It is **not** a standalone application.
+
+## Setup
+
+```bash
+python3 -m venv .venv && . .venv/bin/activate   # optional
+make install                                     # pip install -e ".[dev]"
+```
+
+`requires-python >= 3.12`. Core deps: Django (>=5.0,<6.0), litellm, tenacity, asgiref.
+Optional extras: `nl2sql` (no extra wheels — activate via INSTALLED_APPS), `promptfw`,
+`rag` (pgvector), `all`, `dev`.
+
+## Test / lint / types
+
+```bash
+make test     # python3 -m pytest tests/ --tb=short -q
+make test-v   # verbose
+make lint     # ruff check src/ tests/
+```
+
+- Tests run on in-memory SQLite via `tests/settings.py` (`DJANGO_SETTINGS_MODULE=tests.settings`);
+  no live Postgres or secrets needed. `pytest.ini_options` sets `pythonpath = ["src", "."]`,
+  so `make test` works without an editable install.
+- Lint = ruff (rules `E`, `F`, `I`, line-length 100, `target-version py312`). Migrations are
+  excluded; a few NL2SQL prompt/SQL modules carry a justified per-file `E501` ignore.
+- No mypy configured (the package ships `py.typed` for downstream type checking, but there is
+  no type-check gate in this repo).
+- CI (`.github/workflows/ci.yml`) runs ruff + `pytest -v` on Python 3.12 for push/PR to `main`.
+
+## Architecture (module map)
+
+Source lives under `src/aifw/`:
+
+| Module | Role |
+|---|---|
+| `__init__.py` | Public API surface + `__version__` (read from installed metadata). |
+| `service.py` | Core entrypoints: `completion` / `sync_completion` (+ `_stream`, `_with_fallback`), `get_action_config`, `get_quality_level_for_tier`, cache invalidation. |
+| `models.py` | Django models: AI action types, usage logs (incl. k-anonymity aggregation), tier→quality mappings. |
+| `constants.py` | `QualityLevel`, `PrivacyMode`. |
+| `privacy.py` | Privacy-by-design pre-write transform (`PrivacyHook`, `apply_privacy`, `get_privacy_hook`). |
+| `cost.py` | Cost estimation (`estimate_cost`, `cost_from_rates`). |
+| `schema.py` / `types.py` | `LLMResult`, `ToolCall`, `RenderedPromptProtocol`, `ActionConfig`. |
+| `exceptions.py` | `AIFWError`, `ConfigurationError`, `OrchestrationError`. |
+| `apps.py` / `signals.py` / `admin.py` | Django app wiring. |
+| `management/commands/` | `check_aifw_config`, `init_aifw_config`, `promote_feedback`, `seed_nl2sql_examples`, `validate_schema`. |
+| `nl2sql/` | Optional text-to-SQL subsystem (`engine.py`, `semantic.py`, `clarification.py`, `results.py`, own models/migrations/commands). Activated by adding `aifw.nl2sql` to INSTALLED_APPS. |
+| `migrations/` | Core schema (0001–0009). Auto-generated; not linted. |
+
+## Conventions
+
+- Commits: `[feat|fix|refactor|docs|test|chore](scope): description`.
+- `__version__` is **always** resolved from package metadata — never hardcode it
+  (past 0.10.x metadata/code drift tripped the consumer CI guard).
+- Keep ruff `target-version`, mypy `python_version` (none today), and the Python
+  classifiers consistent with `requires-python`. Do not change `requires-python`
+  casually — it is a consumer-facing contract.
+- `aifw` must not import `iil-promptfw` at runtime; topic classification is an
+  injected callable (privacy hook factory).
+
+## Release (GATED — not on-merge)
+
+Publishing to PyPI is **manual and gated**, never automatic on merge to `main`.
+Merging a PR does **not** publish. A release is a deliberate step (version bump in
+`pyproject.toml` + `CHANGELOG.md`, then the gated `publish.yml` workflow / `/release`
+flow). Agents must not publish, tag, or trigger a release without explicit human
+approval.
+
+## Known issues / gotchas
+
+- Tests emit a pytest naming-convention warning (`test_should_<...>` preferred) for a
+  number of existing tests — cosmetic, not failing.
+- NEXT.md is an **auto-generated editor cache**, not a source of truth — ignore it for
+  planning; use this file + AGENT_HANDOVER.md + CHANGELOG.md.
+- Default `AIFW_PRIVACY_MODE` will flip from `"full"` to `"pseudonymous"` in 0.12.0
+  (documented breaking change); 0.11.x is non-breaking.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -69,6 +69,8 @@ pythonpath = ["src", "."]
 
 [tool.ruff]
 line-length = 100
+# Consistent with requires-python = ">=3.12".
+target-version = "py312"
 # Django migrations are auto-generated; linting them fights the generator.
 extend-exclude = ["**/migrations/**"]
 


### PR DESCRIPTION
## Tier 1 — agent-readiness for `iil-aifw`

Follows the reference set by achimdehnert/iil-adrfw PR #11. Make the package safe
and predictable for an autonomous agent (or stronger model) to build on. **No
behavior change.**

### Changes

- **`pyproject.toml`** — config alignment with `requires-python >= 3.12`:
  - classifiers had a **duplicate** `Programming Language :: Python :: 3.12` and no
    bare `3` — fixed to `3` + `3.12`.
  - added ruff `target-version = "py312"` (was unset, now consistent).
  - no mypy config present → no `python_version` to align. `requires-python`
    untouched.
- **`CLAUDE.md`** (new) — operating guide: what this is, setup, test/lint/types,
  module map, conventions, gated-release note, gotchas.
- **`AGENT_HANDOVER.md`** (new) — living current-state / next-priorities handover.
  Flags `NEXT.md` as an auto-generated cache, not the source of truth.

### Already in place (left as-is)

- `src/aifw/__init__.py` already resolves `__version__` from package metadata
  (with `PackageNotFoundError` fallback), declares `__all__`, documents public API.
- `Makefile` already provides `make test` / `make lint` (no mypy → no `types`).

### Verification

- `make test` → **162 passed** (1 pre-existing cosmetic pytest naming warning)
- `make lint` (ruff) → clean, no worse than before
- `import aifw` resolves `__version__` from package metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)