### PR TITLE
chore(tier2): add coverage gate (pytest-cov, fail-under=45)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pytest>=8.0",
     "pytest-django>=4.8",
     "pytest-asyncio>=0.23",
+    "pytest-cov>=5.0",
     "hatch",
     "ruff",
     "iil-promptfw>=0.7.0",
@@ -66,6 +67,15 @@ sources = {"src" = ""}
 DJANGO_SETTINGS_MODULE = "tests.settings"
 asyncio_mode = "auto"
 pythonpath = ["src", "."]
+# Coverage gate ratchets from the current ~49%. Raise the floor as coverage
+# improves; never lower it silently.
+addopts = "--cov=aifw --cov-report=term-missing --cov-fail-under=45"
+
+[tool.coverage.run]
+source = ["aifw"]
+
+[tool.coverage.report]
+show_missing = true
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Tier 2 — coverage guardrail

aifw had **no** coverage measurement or gate — an agent could add untested code
with CI staying green.

- Add `pytest-cov` to the `dev` extra.
- Add a ratcheting coverage gate to `[tool.pytest.ini_options]`:
  `--cov=aifw --cov-report=term-missing --cov-fail-under=45` (current ~49%).
- CI already runs `pytest tests/` with `.[dev]`, so the gate is enforced in CI.

No code change. 162 passed, coverage ~49%. Raise the floor as coverage improves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)