### PR TITLE
fix(ci): publish-Gate über test-Job verdrahten (needs: test)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ jobs:
 
   build:
     name: Build distribution
+    needs: test
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Ziel
Der Publish-Workflow hat einen Job `test` namens **"Tests (publish gate)"**, der den PyPI-Upload faktisch **nicht** gatet: `build` hatte kein `needs: test`, `publish-pypi` nur `needs: build`. Ein `v*`-Tag-Push hätte damit auch bei **roten Tests** nach PyPI publiziert (Supply-Chain-Lücke).

## Änderung
Eine Zeile: `needs: test` am `build`-Job → Kette ist jetzt `test → build → publish-pypi / publish-testpypi`.

- betroffen: `.github/workflows/publish.yml` (Job `build`)
- konsistent zum bereits korrekt gegateten Muster in **authoringfw / riskfw / weltenfw / learnfw / outlinefw**

## Begründung / Evidenz
Fleet-Grep über alle `publish.yml`: Mehrheit der `*fw` gatet korrekt (test→build→publish), eine Minderheit kopierte die **ungegatete** Variante — **aifw + promptfw** identisch ungegated, **researchfw + nl2cad** publizieren ganz ohne Test-Job. Template-Drift; aifw ist der erste Fix.

## Tests
- YAML-Parse + Job-Graph verifiziert: `build.needs == 'test'`, `publish-pypi.needs == 'build'`.
- Kein Codepfad geändert; reine CI-Verdrahtung. Der test-Job (pytest) ist unverändert.

## Risiken / Nebenwirkungen
- Minimal & strikt sicherer: das Gate wird **strenger** (Publish nur nach grünem test). Kein Einfluss auf Laufzeit-Code oder bestehende veröffentlichte Versionen.

## Bezug
Stufe-1 LLM-Readiness/Robustheit-Analyse, Befund aifw-F1. Schwester-Repos (promptfw/researchfw/nl2cad) werden **nicht** hier gefixt, sondern als Quell-Fix (shared-ci publish-Template) gebündelt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)