### PR TITLE
chore(deps): Dependabot-Grundausstattung (ADR-266 Stufe 3b)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Dependabot — ADR-266 Stufe 3b (PyPI-Paket-Repos)
+# Monatlich, gruppiert (ein Sammel-PR statt PR-Spam); Publish bleibt manuell —
+# Dependabot-PRs werden NIE auto-gemergt (Gate autonomous-no-human-review).
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      python-deps:
+        patterns: ["*"]
+    open-pull-requests-limit: 3
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]
+    open-pull-requests-limit: 2


### PR DESCRIPTION
Dependabot-Grundausstattung für PyPI-Paket-Repos (platform ADR-266 Stufe 3b, freigegeben 2026-07-04):
monatlich + gruppiert (kein PR-Spam), pip + github-actions, kein Auto-Merge.
Kontext: platform docs/adr/ADR-266 · Tracking: Label pypi-fleet-health in platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
