### PR TITLE
chore(ci): Konvergenz auf _ci-pypi.yml (ADR-266 Stufe 2b)

### DIFF
--- a/.github/scripts/bootstrap_labels.py
+++ b/.github/scripts/bootstrap_labels.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python3
 """Usage: python .github/scripts/bootstrap_labels.py --repo owner/repo --token $GITHUB_TOKEN"""
-import argparse, requests
+
+import argparse
+
+import requests
 
 LABELS = [
-    {"name": "bug",           "color": "d73a4a", "description": "Fehler"},
-    {"name": "enhancement",   "color": "a2eeef", "description": "Neue Funktion"},
-    {"name": "task",          "color": "e4e669", "description": "Technische Aufgabe"},
-    {"name": "use-case",      "color": "0075ca", "description": "Use Case"},
-    {"name": "adr",           "color": "7057ff", "description": "Architecture Decision"},
-    {"name": "triage",        "color": "e99695", "description": "Neu, nicht bewertet"},
-    {"name": "wontfix",       "color": "ffffff", "description": "Nicht umgesetzt"},
-    {"name": "blocked",       "color": "ee0701", "description": "Blockiert"},
+    {"name": "bug", "color": "d73a4a", "description": "Fehler"},
+    {"name": "enhancement", "color": "a2eeef", "description": "Neue Funktion"},
+    {"name": "task", "color": "e4e669", "description": "Technische Aufgabe"},
+    {"name": "use-case", "color": "0075ca", "description": "Use Case"},
+    {"name": "adr", "color": "7057ff", "description": "Architecture Decision"},
+    {"name": "triage", "color": "e99695", "description": "Neu, nicht bewertet"},
+    {"name": "wontfix", "color": "ffffff", "description": "Nicht umgesetzt"},
+    {"name": "blocked", "color": "ee0701", "description": "Blockiert"},
     {"name": "documentation", "color": "0075ca", "description": "Dokumentation"},
-    {"name": "security",      "color": "ee0701", "description": "Sicherheitsrelevant"},
-    {"name": "dependencies",  "color": "0366d6", "description": "Dependency Update"},
+    {"name": "security", "color": "ee0701", "description": "Sicherheitsrelevant"},
+    {"name": "dependencies", "color": "0366d6", "description": "Dependency Update"},
 ]
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -22,15 +26,26 @@ def main():
     parser.add_argument("--token", required=True)
     args = parser.parse_args()
     session = requests.Session()
-    session.headers.update({"Authorization": f"Bearer {args.token}", "Accept": "application/vnd.github+json"})
-    existing = {l["name"] for l in session.get(f"https://api.github.com/repos/{args.repo}/labels", params={"per_page": 100}).json()}
+    session.headers.update(
+        {"Authorization": f"Bearer {args.token}", "Accept": "application/vnd.github+json"}
+    )
+    existing = {
+        label["name"]
+        for label in session.get(
+            f"https://api.github.com/repos/{args.repo}/labels", params={"per_page": 100}
+        ).json()
+    }
     for label in LABELS:
         if label["name"] in existing:
-            session.patch(f"https://api.github.com/repos/{args.repo}/labels/{requests.utils.quote(label['name'])}", json=label)
+            session.patch(
+                f"https://api.github.com/repos/{args.repo}/labels/{requests.utils.quote(label['name'])}",
+                json=label,
+            )
             print(f"updated: {label['name']}")
         else:
             session.post(f"https://api.github.com/repos/{args.repo}/labels", json=label)
             print(f"created: {label['name']}")
+
 
 if __name__ == "__main__":
     main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,22 @@
+# ci.yml — Thin-Caller auf das ADR-226-Reusable (platform ADR-266 Stufe 2b).
+# Semantik (Lint, Secret-Scan, Test+Coverage, Build+Artefakt-Scan, pip-audit)
+# lebt zentral in platform/.github/workflows/_ci-pypi.yml — Verbesserungen
+# erreichen alle Pakete in O(1). Inputs abgeleitet aus der Vorgänger-ci.yml.
+
 name: CI
 
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12"]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          pip install --upgrade pip
-          pip install -e ".[dev]"
-
-      - name: Lint with ruff
-        run: ruff check src/ tests/
-
-      - name: Run tests
-        run: pytest tests/ -v --tb=short
+  ci:
+    uses: achimdehnert/platform/.github/workflows/_ci-pypi.yml@main
+    with:
+      python_versions: '["3.12"]'
+      install_extra: 'dev'
+      test_path: 'tests/'

--- a/src/aifw/admin.py
+++ b/src/aifw/admin.py
@@ -18,8 +18,14 @@ class LLMModelAdmin(admin.ModelAdmin):
 @admin.register(AIActionType)
 class AIActionTypeAdmin(admin.ModelAdmin):
     list_display = [
-        "code", "name", "quality_level", "priority",
-        "default_model", "fallback_model", "prompt_template_key", "is_active",
+        "code",
+        "name",
+        "quality_level",
+        "priority",
+        "default_model",
+        "fallback_model",
+        "prompt_template_key",
+        "is_active",
     ]
     list_filter = ["is_active", "quality_level", "priority"]
     search_fields = ["code", "name"]
@@ -36,13 +42,30 @@ class TierQualityMappingAdmin(admin.ModelAdmin):
 @admin.register(AIUsageLog)
 class AIUsageLogAdmin(admin.ModelAdmin):
     list_display = [
-        "action_type", "model_used", "quality_level", "privacy_mode", "user",
-        "total_tokens", "estimated_cost", "latency_ms", "success", "created_at",
+        "action_type",
+        "model_used",
+        "quality_level",
+        "privacy_mode",
+        "user",
+        "total_tokens",
+        "estimated_cost",
+        "latency_ms",
+        "success",
+        "created_at",
     ]
     list_filter = ["success", "privacy_mode", "quality_level", "action_type", "model_used"]
     readonly_fields = [
-        "action_type", "model_used", "user", "quality_level", "privacy_mode",
-        "input_tokens", "output_tokens", "total_tokens",
-        "estimated_cost", "latency_ms", "success",
-        "error_message", "created_at",
+        "action_type",
+        "model_used",
+        "user",
+        "quality_level",
+        "privacy_mode",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "estimated_cost",
+        "latency_ms",
+        "success",
+        "error_message",
+        "created_at",
     ]

--- a/src/aifw/constants.py
+++ b/src/aifw/constants.py
@@ -3,6 +3,7 @@ aifw/constants.py — Shared constants for quality-level routing.
 
 ADR-095 §5.1 — QualityLevel scale definition.
 """
+
 from __future__ import annotations
 
 
@@ -14,9 +15,9 @@ class QualityLevel:
         quality = QualityLevel.PREMIUM  # 8
     """
 
-    ECONOMY: int = 2   # 1–3 band centre
+    ECONOMY: int = 2  # 1–3 band centre
     BALANCED: int = 5  # 4–6 band centre
-    PREMIUM: int = 8   # 7–9 band centre
+    PREMIUM: int = 8  # 7–9 band centre
 
     #: All valid values (1–9 inclusive)
     ALL: tuple[int, ...] = (1, 2, 3, 4, 5, 6, 7, 8, 9)
@@ -55,9 +56,9 @@ class PrivacyMode:
         AIFW_PRIVACY_MODE = PrivacyMode.PSEUDONYMOUS
     """
 
-    FULL: str = "full"                  # legacy default — user + metadata raw
+    FULL: str = "full"  # legacy default — user + metadata raw
     PSEUDONYMOUS: str = "pseudonymous"  # HMAC user_hash + classified topic
-    ANONYMOUS: str = "anonymous"        # tenant + tokens + day_bucket only
+    ANONYMOUS: str = "anonymous"  # tenant + tokens + day_bucket only
 
     #: All valid mode strings
     ALL: tuple[str, ...] = (FULL, PSEUDONYMOUS, ANONYMOUS)

--- a/src/aifw/exceptions.py
+++ b/src/aifw/exceptions.py
@@ -3,6 +3,7 @@ aifw/exceptions.py — Exception hierarchy for aifw.
 
 ADR-097 §4 — Exception hierarchy.
 """
+
 from __future__ import annotations
 
 

--- a/src/aifw/management/commands/check_aifw_config.py
+++ b/src/aifw/management/commands/check_aifw_config.py
@@ -17,6 +17,7 @@ Intended for CI pre-deploy checks and Docker entrypoint health gates.
 
 ADR-097 G-097-01.
 """
+
 from __future__ import annotations
 
 from django.core.management.base import BaseCommand, CommandError

--- a/src/aifw/management/commands/init_aifw_config.py
+++ b/src/aifw/management/commands/init_aifw_config.py
@@ -93,20 +93,15 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         for p in PROVIDERS:
             defaults = {k: v for k, v in p.items() if k != "name"}
-            obj, created = LLMProvider.objects.get_or_create(
-                name=p["name"], defaults=defaults
-            )
-            self.stdout.write(
-                f"{'Created' if created else 'Exists'}: Provider {obj.display_name}"
-            )
+            obj, created = LLMProvider.objects.get_or_create(name=p["name"], defaults=defaults)
+            self.stdout.write(f"{'Created' if created else 'Exists'}: Provider {obj.display_name}")
 
         for m in MODELS:
             provider = LLMProvider.objects.filter(name=m["provider"]).first()
             if not provider:
                 self.stdout.write(
                     self.style.WARNING(
-                        f"  Skipped model {m['name']}: "
-                        f"provider '{m['provider']}' not found"
+                        f"  Skipped model {m['name']}: provider '{m['provider']}' not found"
                     )
                 )
                 continue
@@ -115,9 +110,7 @@ class Command(BaseCommand):
             obj, created = LLMModel.objects.get_or_create(
                 provider=provider, name=m["name"], defaults=defaults
             )
-            self.stdout.write(
-                f"{'Created' if created else 'Exists'}: Model {obj.display_name}"
-            )
+            self.stdout.write(f"{'Created' if created else 'Exists'}: Model {obj.display_name}")
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/src/aifw/management/commands/promote_feedback.py
+++ b/src/aifw/management/commands/promote_feedback.py
@@ -10,6 +10,7 @@ Usage:
     python manage.py promote_feedback --min-age-hours 1
     python manage.py promote_feedback --dry-run
 """
+
 from __future__ import annotations
 
 from datetime import timedelta
@@ -70,18 +71,14 @@ class Command(BaseCommand):
             ).exists()
 
             if exists:
-                self.stdout.write(
-                    self.style.WARNING(f"  SKIP (Duplicate): {fb.question[:60]}")
-                )
+                self.stdout.write(self.style.WARNING(f"  SKIP (Duplicate): {fb.question[:60]}"))
                 if not dry_run:
                     fb.promoted = True
                     fb.save(update_fields=["promoted"])
                 skipped_count += 1
                 continue
 
-            self.stdout.write(
-                f"  ✓ [{fb.source.code}] [{fb.error_type}] {fb.question[:60]}"
-            )
+            self.stdout.write(f"  ✓ [{fb.source.code}] [{fb.error_type}] {fb.question[:60]}")
 
             if not dry_run:
                 NL2SQLExample.objects.create(

--- a/src/aifw/management/commands/seed_nl2sql_examples.py
+++ b/src/aifw/management/commands/seed_nl2sql_examples.py
@@ -9,6 +9,7 @@ Usage:
     python manage.py seed_nl2sql_examples --source odoo_mfg
     python manage.py seed_nl2sql_examples --clear
 """
+
 from __future__ import annotations
 
 from django.core.management.base import BaseCommand
@@ -20,10 +21,10 @@ EXAMPLES = {
             "question": "Welche Maschinen sind gerade in Störung?",
             "sql": (
                 "SELECT\n"
-                "  name        AS \"Maschine\",\n"
-                "  code        AS \"Code\",\n"
-                "  hall        AS \"Halle\",\n"
-                "  state       AS \"Status\"\n"
+                '  name        AS "Maschine",\n'
+                '  code        AS "Code",\n'
+                '  hall        AS "Halle",\n'
+                '  state       AS "Status"\n'
                 "FROM casting_machine\n"
                 "WHERE state = 'breakdown' AND active = true\n"
                 "ORDER BY name"
@@ -35,12 +36,12 @@ EXAMPLES = {
             "question": "Wie viele Maschinen sind in welchem Status?",
             "sql": (
                 "SELECT\n"
-                "  state       AS \"Status\",\n"
-                "  COUNT(*)    AS \"Anzahl Maschinen\"\n"
+                '  state       AS "Status",\n'
+                '  COUNT(*)    AS "Anzahl Maschinen"\n'
                 "FROM casting_machine\n"
                 "WHERE active = true\n"
                 "GROUP BY state\n"
-                "ORDER BY \"Anzahl Maschinen\" DESC"
+                'ORDER BY "Anzahl Maschinen" DESC'
             ),
             "domain": "machines",
             "difficulty": 1,
@@ -49,15 +50,15 @@ EXAMPLES = {
             "question": "Top 5 Maschinen nach aktiven Aufträgen",
             "sql": (
                 "SELECT\n"
-                "  cm.name                         AS \"Maschine\",\n"
-                "  COUNT(DISTINCT col.order_id)    AS \"Aktive Aufträge\"\n"
+                '  cm.name                         AS "Maschine",\n'
+                '  COUNT(DISTINCT col.order_id)    AS "Aktive Aufträge"\n'
                 "FROM casting_order_line col\n"
                 "JOIN casting_machine cm ON cm.id = col.machine_id\n"
                 "JOIN casting_order co ON co.id = col.order_id\n"
                 "WHERE co.state IN ('confirmed', 'in_production')\n"
                 "  AND cm.active = true\n"
                 "GROUP BY cm.name\n"
-                "ORDER BY \"Aktive Aufträge\" DESC\n"
+                'ORDER BY "Aktive Aufträge" DESC\n'
                 "LIMIT 5"
             ),
             "domain": "machines",
@@ -67,14 +68,14 @@ EXAMPLES = {
             "question": "Welche Maschine hat die meiste Wartung?",
             "sql": (
                 "SELECT\n"
-                "  cm.name     AS \"Maschine\",\n"
-                "  cm.state    AS \"Status\",\n"
-                "  COUNT(*)    AS \"Wartungsvorgänge\"\n"
+                '  cm.name     AS "Maschine",\n'
+                '  cm.state    AS "Status",\n'
+                '  COUNT(*)    AS "Wartungsvorgänge"\n'
                 "FROM casting_order_line col\n"
                 "JOIN casting_machine cm ON cm.id = col.machine_id\n"
                 "WHERE cm.state = 'maintenance'\n"
                 "GROUP BY cm.name, cm.state\n"
-                "ORDER BY \"Wartungsvorgänge\" DESC\n"
+                'ORDER BY "Wartungsvorgänge" DESC\n'
                 "LIMIT 1"
             ),
             "domain": "machines",
@@ -85,11 +86,11 @@ EXAMPLES = {
             "question": "Wie viele Aufträge gibt es je Status?",
             "sql": (
                 "SELECT\n"
-                "  state       AS \"Status\",\n"
-                "  COUNT(*)    AS \"Anzahl Aufträge\"\n"
+                '  state       AS "Status",\n'
+                '  COUNT(*)    AS "Anzahl Aufträge"\n'
                 "FROM casting_order\n"
                 "GROUP BY state\n"
-                "ORDER BY \"Anzahl Aufträge\" DESC"
+                'ORDER BY "Anzahl Aufträge" DESC'
             ),
             "domain": "casting",
             "difficulty": 1,
@@ -98,11 +99,11 @@ EXAMPLES = {
             "question": "Welche Aufträge sind aktuell in Produktion?",
             "sql": (
                 "SELECT\n"
-                "  name                AS \"Auftrag\",\n"
-                "  state               AS \"Status\",\n"
-                "  date_planned        AS \"Geplant bis\",\n"
-                "  total_pieces        AS \"Stückzahl\",\n"
-                "  total_scrap_pct     AS \"Ausschuss %\"\n"
+                '  name                AS "Auftrag",\n'
+                '  state               AS "Status",\n'
+                '  date_planned        AS "Geplant bis",\n'
+                '  total_pieces        AS "Stückzahl",\n'
+                '  total_scrap_pct     AS "Ausschuss %"\n'
                 "FROM casting_order\n"
                 "WHERE state = 'in_production'\n"
                 "ORDER BY date_planned\n"
@@ -115,11 +116,11 @@ EXAMPLES = {
             "question": "Zeige Aufträge mit Ausschuss über 5%",
             "sql": (
                 "SELECT\n"
-                "  name                AS \"Auftrag\",\n"
-                "  state               AS \"Status\",\n"
-                "  total_scrap_pct     AS \"Ausschuss %\",\n"
-                "  total_pieces        AS \"Stückzahl\",\n"
-                "  date_planned        AS \"Geplant bis\"\n"
+                '  name                AS "Auftrag",\n'
+                '  state               AS "Status",\n'
+                '  total_scrap_pct     AS "Ausschuss %",\n'
+                '  total_pieces        AS "Stückzahl",\n'
+                '  date_planned        AS "Geplant bis"\n'
                 "FROM casting_order\n"
                 "WHERE total_scrap_pct > 5\n"
                 "ORDER BY total_scrap_pct DESC\n"
@@ -132,10 +133,10 @@ EXAMPLES = {
             "question": "Welche Aufträge sind diese Woche fällig?",
             "sql": (
                 "SELECT\n"
-                "  name                AS \"Auftrag\",\n"
-                "  state               AS \"Status\",\n"
-                "  date_planned        AS \"Fällig am\",\n"
-                "  total_pieces        AS \"Stückzahl\"\n"
+                '  name                AS "Auftrag",\n'
+                '  state               AS "Status",\n'
+                '  date_planned        AS "Fällig am",\n'
+                '  total_pieces        AS "Stückzahl"\n'
                 "FROM casting_order\n"
                 "WHERE date_planned >= date_trunc('week', CURRENT_DATE)\n"
                 "  AND date_planned < date_trunc('week', CURRENT_DATE) + INTERVAL '7 days'\n"
@@ -152,11 +153,11 @@ EXAMPLES = {
                 "SELECT\n"
                 "  COUNT(*) FILTER (WHERE result = 'pass')  AS \"Bestanden\",\n"
                 "  COUNT(*) FILTER (WHERE result = 'fail')  AS \"Nicht bestanden\",\n"
-                "  COUNT(*)                                  AS \"Gesamt\",\n"
+                '  COUNT(*)                                  AS "Gesamt",\n'
                 "  ROUND(\n"
                 "    100.0 * COUNT(*) FILTER (WHERE result = 'pass')\n"
                 "    / NULLIF(COUNT(*), 0), 1\n"
-                "  )                                         AS \"Bestehensrate %\"\n"
+                '  )                                         AS "Bestehensrate %"\n'
                 "FROM casting_quality_check"
             ),
             "domain": "casting",
@@ -167,10 +168,10 @@ EXAMPLES = {
             "question": "Welche Einkaufsbestellungen sind überfällig?",
             "sql": (
                 "SELECT\n"
-                "  name            AS \"Bestellung\",\n"
-                "  state           AS \"Status\",\n"
-                "  date_expected   AS \"Erwartet am\",\n"
-                "  total_amount    AS \"Betrag EUR\"\n"
+                '  name            AS "Bestellung",\n'
+                '  state           AS "Status",\n'
+                '  date_expected   AS "Erwartet am",\n'
+                '  total_amount    AS "Betrag EUR"\n'
                 "FROM scm_purchase_order\n"
                 "WHERE date_expected < CURRENT_DATE\n"
                 "  AND state NOT IN ('received', 'cancelled', 'done')\n"
@@ -184,11 +185,11 @@ EXAMPLES = {
             "question": "Wie viele SCM-Aufträge laufen aktuell?",
             "sql": (
                 "SELECT\n"
-                "  state       AS \"Status\",\n"
-                "  COUNT(*)    AS \"Anzahl Aufträge\"\n"
+                '  state       AS "Status",\n'
+                '  COUNT(*)    AS "Anzahl Aufträge"\n'
                 "FROM scm_production_order\n"
                 "GROUP BY state\n"
-                "ORDER BY \"Anzahl Aufträge\" DESC"
+                'ORDER BY "Anzahl Aufträge" DESC'
             ),
             "domain": "scm",
             "difficulty": 1,
@@ -241,9 +242,7 @@ class Command(BaseCommand):
         skipped_count = 0
 
         for ex in examples:
-            exists = NL2SQLExample.objects.filter(
-                source=source, question=ex["question"]
-            ).exists()
+            exists = NL2SQLExample.objects.filter(source=source, question=ex["question"]).exists()
             if exists:
                 skipped_count += 1
                 continue
@@ -257,7 +256,7 @@ class Command(BaseCommand):
                 is_active=True,
             )
             created_count += 1
-            self.stdout.write(f"  ✓ [{ex.get('domain','')}] {ex['question'][:60]}")
+            self.stdout.write(f"  ✓ [{ex.get('domain', '')}] {ex['question'][:60]}")
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/src/aifw/management/commands/validate_schema.py
+++ b/src/aifw/management/commands/validate_schema.py
@@ -11,6 +11,7 @@ Usage:
     python manage.py validate_schema --source odoo_mfg
     python manage.py validate_schema --fix-hints
 """
+
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
@@ -20,6 +21,7 @@ from django.core.management.base import BaseCommand
 
 def _get_db_columns(db_alias: str, table_name: str) -> set[str]:
     from django.db import connections
+
     conn = connections[db_alias]
     with conn.cursor() as cur:
         cur.execute(
@@ -32,6 +34,7 @@ def _get_db_columns(db_alias: str, table_name: str) -> set[str]:
 
 def _get_db_tables(db_alias: str) -> set[str]:
     from django.db import connections
+
     conn = connections[db_alias]
     with conn.cursor() as cur:
         cur.execute(
@@ -67,9 +70,9 @@ class Command(BaseCommand):
         total_warnings = 0
 
         for source in qs:
-            self.stdout.write(f"\n{'='*60}")
+            self.stdout.write(f"\n{'=' * 60}")
             self.stdout.write(f"Source: {source.code} (DB: {source.db_alias})")
-            self.stdout.write("="*60)
+            self.stdout.write("=" * 60)
 
             errors = []
             warnings = []
@@ -114,9 +117,7 @@ class Command(BaseCommand):
                     if not col_name:
                         continue
                     if col_name not in db_cols:
-                        errors.append(
-                            f"Spalte '{table_name}.{col_name}' existiert NICHT in DB"
-                        )
+                        errors.append(f"Spalte '{table_name}.{col_name}' existiert NICHT in DB")
                         self.stdout.write(
                             self.style.ERROR(f"    ✗ Spalte '{col_name}' — nicht in DB")
                         )
@@ -134,7 +135,7 @@ class Command(BaseCommand):
             total_errors += len(errors)
             total_warnings += len(warnings)
 
-        self.stdout.write(f"\n{'='*60}")
+        self.stdout.write(f"\n{'=' * 60}")
         if total_errors == 0:
             self.stdout.write(
                 self.style.SUCCESS(

--- a/src/aifw/models.py
+++ b/src/aifw/models.py
@@ -17,6 +17,7 @@ New in 0.6.1:
 Uniqueness on AIActionType is enforced by 4 partial unique indexes (migration 0005),
 not unique_together — required due to PostgreSQL NULL != NULL semantics.
 """
+
 from __future__ import annotations
 
 import logging
@@ -54,20 +55,14 @@ class LLMProvider(models.Model):
 class LLMModel(models.Model):
     """Available LLM models with cost & capability metadata."""
 
-    provider = models.ForeignKey(
-        LLMProvider, on_delete=models.PROTECT, related_name="models"
-    )
+    provider = models.ForeignKey(LLMProvider, on_delete=models.PROTECT, related_name="models")
     name = models.CharField(max_length=100)
     display_name = models.CharField(max_length=100)
     max_tokens = models.IntegerField(default=4096)
     supports_vision = models.BooleanField(default=False)
     supports_tools = models.BooleanField(default=True)
-    input_cost_per_million = models.DecimalField(
-        max_digits=10, decimal_places=4, default=0
-    )
-    output_cost_per_million = models.DecimalField(
-        max_digits=10, decimal_places=4, default=0
-    )
+    input_cost_per_million = models.DecimalField(max_digits=10, decimal_places=4, default=0)
+    output_cost_per_million = models.DecimalField(max_digits=10, decimal_places=4, default=0)
     is_active = models.BooleanField(default=True)
     is_default = models.BooleanField(default=False)
 
@@ -190,9 +185,7 @@ class AIActionType(models.Model):
                 f"Valid values: {sorted(VALID_PRIORITIES)} or None."
             )
         if self.quality_level is not None and not QualityLevel.is_valid(self.quality_level):
-            raise ValidationError(
-                f"quality_level must be 1–9 or None, got {self.quality_level}."
-            )
+            raise ValidationError(f"quality_level must be 1–9 or None, got {self.quality_level}.")
 
     def get_model(self) -> LLMModel | None:
         """Return the effective model respecting budget limits."""
@@ -286,9 +279,7 @@ class TierQualityMapping(models.Model):
 class AIUsageLogQuerySet(models.QuerySet):
     """Custom queryset with a k-anonymity aggregation helper (issue #8)."""
 
-    def aggregate_with_k_anonymity(
-        self, *group_by: str, k: int = 3
-    ) -> "models.QuerySet":
+    def aggregate_with_k_anonymity(self, *group_by: str, k: int = 3) -> "models.QuerySet":
         """Group by the given fields, returning only buckets with ≥ k entries.
 
         Useful for supervisor-facing usage views without re-identification risk:
@@ -323,12 +314,8 @@ class AIUsageLog(models.Model):
     write time (issue #8). See aifw.privacy for the pre-write transform.
     """
 
-    action_type = models.ForeignKey(
-        AIActionType, on_delete=models.SET_NULL, null=True, blank=True
-    )
-    model_used = models.ForeignKey(
-        LLMModel, on_delete=models.SET_NULL, null=True, blank=True
-    )
+    action_type = models.ForeignKey(AIActionType, on_delete=models.SET_NULL, null=True, blank=True)
+    model_used = models.ForeignKey(LLMModel, on_delete=models.SET_NULL, null=True, blank=True)
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.SET_NULL,
@@ -402,6 +389,7 @@ class AIUsageLog(models.Model):
 
     def save(self, *args, **kwargs) -> None:
         from aifw.cost import estimate_cost
+
         self.total_tokens = self.input_tokens + self.output_tokens
         if not self.estimated_cost:
             self.estimated_cost = estimate_cost(

--- a/src/aifw/nl2sql/apps.py
+++ b/src/aifw/nl2sql/apps.py
@@ -10,6 +10,7 @@ Activate by adding "aifw.nl2sql" to INSTALLED_APPS:
 Projects that don't need NL2SQL (travel-beat, writing-hub, weltenhub)
 simply omit this entry — no tables are created, no overhead.
 """
+
 from django.apps import AppConfig
 
 

--- a/src/aifw/nl2sql/clarification.py
+++ b/src/aifw/nl2sql/clarification.py
@@ -18,6 +18,7 @@ Usage::
         print(result.question)
         print(result.options)
 """
+
 from __future__ import annotations
 
 import json
@@ -29,37 +30,42 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ClarificationOption:
-    label: str        # "Maschinen"
+    label: str  # "Maschinen"
     description: str  # "Betriebsstatus, Verfügbarkeit, Störungen"
-    hint: str         # Wird an Frage angehängt: "— bezogen auf Maschinen"
+    hint: str  # Wird an Frage angehängt: "— bezogen auf Maschinen"
 
 
 @dataclass
 class ClarificationResult:
     is_ambiguous: bool
-    confidence: float            # 0.0 = eindeutig, 1.0 = maximal ambig
+    confidence: float  # 0.0 = eindeutig, 1.0 = maximal ambig
     reason: str
-    question: str                # Rückfrage an User
+    question: str  # Rückfrage an User
     options: list[ClarificationOption] = field(default_factory=list)
 
     @classmethod
     def from_json(cls, raw: str) -> "ClarificationResult":
         # Extract JSON block — handles Markdown fences and stray text
         import re
-        match = re.search(r'\{.*\}', raw, re.DOTALL)
+
+        match = re.search(r"\{.*\}", raw, re.DOTALL)
         if match:
             raw = match.group(0)
         data = json.loads(raw)
         opts = []
         for o in data.get("options", []):
             if isinstance(o, str):
-                opts.append(ClarificationOption(label=o, description="", hint=f"\u2014 bezogen auf {o}"))
+                opts.append(
+                    ClarificationOption(label=o, description="", hint=f"\u2014 bezogen auf {o}")
+                )
             elif isinstance(o, dict):
-                opts.append(ClarificationOption(
-                    label=o.get("label", ""),
-                    description=o.get("description", ""),
-                    hint=o.get("hint", ""),
-                ))
+                opts.append(
+                    ClarificationOption(
+                        label=o.get("label", ""),
+                        description=o.get("description", ""),
+                        hint=o.get("hint", ""),
+                    )
+                )
         return cls(
             is_ambiguous=bool(data.get("is_ambiguous", False)),
             confidence=float(data.get("confidence", 0.5)),
@@ -128,12 +134,43 @@ class ClarificationDetector:
 
     # Keywords die auf eine spezifische Frage hindeuten → skip LLM call
     _SPECIFIC_KEYWORDS = [
-        "maschine", "maschinen", "auftrag", "aufträge", "störung", "ausschuss",
-        "teil", "teile", "produkt", "produkte", "bestand", "nullbestand",
-        "lieferant", "lieferanten", "top", "wie viele", "zeige", "liste",
-        "qualität", "prüfung", "wartung", "lager", "einkauf", "bestellung",
-        "fällig", "überfällig", "kritisch", "aktiv", "letzte", "diese woche",
-        "legierung", "guss", "gieß", "form", "halle", "country", "partner",
+        "maschine",
+        "maschinen",
+        "auftrag",
+        "aufträge",
+        "störung",
+        "ausschuss",
+        "teil",
+        "teile",
+        "produkt",
+        "produkte",
+        "bestand",
+        "nullbestand",
+        "lieferant",
+        "lieferanten",
+        "top",
+        "wie viele",
+        "zeige",
+        "liste",
+        "qualität",
+        "prüfung",
+        "wartung",
+        "lager",
+        "einkauf",
+        "bestellung",
+        "fällig",
+        "überfällig",
+        "kritisch",
+        "aktiv",
+        "letzte",
+        "diese woche",
+        "legierung",
+        "guss",
+        "gieß",
+        "form",
+        "halle",
+        "country",
+        "partner",
     ]
 
     def __init__(
@@ -217,7 +254,11 @@ class ClarificationDetector:
             cr.is_ambiguous = cr.confidence >= effective_threshold
             return cr
         except Exception as exc:
-            logger.warning("ClarificationDetector JSON-Parse-Fehler: %s | raw: %s", exc, llm_result.content[:200])
+            logger.warning(
+                "ClarificationDetector JSON-Parse-Fehler: %s | raw: %s",
+                exc,
+                llm_result.content[:200],
+            )
             return _fail_open()
 
 

--- a/src/aifw/nl2sql/engine.py
+++ b/src/aifw/nl2sql/engine.py
@@ -13,6 +13,7 @@ Pipeline:
   8. Format result + auto-detect chart type
   9. Return NL2SQLResult
 """
+
 from __future__ import annotations
 
 import logging
@@ -30,18 +31,42 @@ from aifw.nl2sql.results import (
 logger = logging.getLogger(__name__)
 
 ALWAYS_BLOCKED = {
-    "auth_user", "auth_password", "auth_token",
-    "django_session", "authtoken_token",
-    "oauth2_provider_accesstoken", "res_users_keys",
+    "auth_user",
+    "auth_password",
+    "auth_token",
+    "django_session",
+    "authtoken_token",
+    "oauth2_provider_accesstoken",
+    "res_users_keys",
     "ir_config_parameter",
 }
 
-FORBIDDEN_SQL_KEYWORDS = frozenset([
-    "DROP", "TRUNCATE", "ALTER", "CREATE", "GRANT", "REVOKE",
-    "COPY", "EXECUTE", "DO", "IMPORT", "LOAD", "VACUUM",
-    "CLUSTER", "REINDEX", "COMMENT", "SECURITY", "OWNER",
-    "INSERT", "UPDATE", "DELETE", "MERGE", "UPSERT",
-])
+FORBIDDEN_SQL_KEYWORDS = frozenset(
+    [
+        "DROP",
+        "TRUNCATE",
+        "ALTER",
+        "CREATE",
+        "GRANT",
+        "REVOKE",
+        "COPY",
+        "EXECUTE",
+        "DO",
+        "IMPORT",
+        "LOAD",
+        "VACUUM",
+        "CLUSTER",
+        "REINDEX",
+        "COMMENT",
+        "SECURITY",
+        "OWNER",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "MERGE",
+        "UPSERT",
+    ]
+)
 
 SYSTEM_PROMPT_TEMPLATE = """Du bist ein präziser SQL-Generator für PostgreSQL.
 
@@ -104,7 +129,7 @@ def _extract_sql(raw: str) -> str | None:
         return raw
     match = re.search(r"(WITH\s+\w|SELECT\s+)", raw, re.IGNORECASE)
     if match:
-        return raw[match.start():].strip()
+        return raw[match.start() :].strip()
     return None
 
 
@@ -285,9 +310,7 @@ def _execute_query(
             if is_postgres and timeout_seconds > 0:
                 # statement_timeout via SET LOCAL only takes effect inside a
                 # transaction — under autocommit it was previously a silent no-op.
-                cursor.execute(
-                    f"SET LOCAL statement_timeout = {timeout_seconds * 1000}"
-                )
+                cursor.execute(f"SET LOCAL statement_timeout = {timeout_seconds * 1000}")
             cursor.execute(limited_sql)
             return cursor.fetchall(), (cursor.description or [])
 
@@ -350,12 +373,14 @@ class NL2SQLEngine:
         # Einmalig instanziieren — nicht pro _run()-Aufruf
         if clarification_domains:
             from aifw.nl2sql.clarification import ClarificationDetector
+
             self._clarifier: Any = ClarificationDetector(domains=clarification_domains)
         else:
             self._clarifier = None
         # Semantic Bridge — opt-in, non-breaking
         if enable_semantic:
             from aifw.nl2sql.semantic import SemanticBridge
+
             self._semantic: Any = SemanticBridge.from_schema_source(source_code)
         else:
             self._semantic = None
@@ -364,6 +389,7 @@ class NL2SQLEngine:
         if self._source is not None:
             return self._source
         from aifw.nl2sql.models import SchemaSource
+
         source = SchemaSource.objects.filter(code=self.source_code, is_active=True).first()
         if source is None:
             raise ValueError(
@@ -376,9 +402,11 @@ class NL2SQLEngine:
     def _load_examples(self, source) -> list:
         try:
             from aifw.nl2sql.models import NL2SQLExample
+
             return list(
-                NL2SQLExample.objects.filter(source=source, is_active=True)
-                .order_by("difficulty", "id")[:15]
+                NL2SQLExample.objects.filter(source=source, is_active=True).order_by(
+                    "difficulty", "id"
+                )[:15]
             )
         except Exception:
             return []
@@ -394,6 +422,7 @@ class NL2SQLEngine:
     def _capture_feedback(self, source, question: str, bad_sql: str, error_msg: str) -> int | None:
         try:
             from aifw.nl2sql.models import NL2SQLFeedback
+
             fb = NL2SQLFeedback.objects.create(
                 source=source,
                 question=question,
@@ -407,7 +436,11 @@ class NL2SQLEngine:
             return None
 
     def _auto_promote_correction(
-        self, feedback_pk: int | None, source, question: str, corrected_sql: str,
+        self,
+        feedback_pk: int | None,
+        source,
+        question: str,
+        corrected_sql: str,
     ) -> None:
         """When retry succeeds, store corrected SQL and auto-promote to example."""
         if feedback_pk is None:
@@ -421,7 +454,8 @@ class NL2SQLEngine:
             fb.save(update_fields=["corrected_sql", "promoted"])
 
             exists = NL2SQLExample.objects.filter(
-                source=source, question=question,
+                source=source,
+                question=question,
             ).exists()
             if not exists:
                 NL2SQLExample.objects.create(
@@ -435,7 +469,8 @@ class NL2SQLEngine:
                 )
                 logger.info(
                     "NL2SQL auto-promoted: '%s' → Example (from feedback #%d)",
-                    question[:60], feedback_pk,
+                    question[:60],
+                    feedback_pk,
                 )
         except Exception as e:
             logger.warning("Auto-promote fehlgeschlagen: %s", e)
@@ -448,8 +483,7 @@ class NL2SQLEngine:
             from aifw.nl2sql.models import NL2SQLFeedback
 
             patterns = (
-                NL2SQLFeedback.objects
-                .filter(source=source, promoted=False)
+                NL2SQLFeedback.objects.filter(source=source, promoted=False)
                 .values("error_type", "error_message")
                 .annotate(count=Count("id"))
                 .filter(count__gte=2)
@@ -490,7 +524,11 @@ class NL2SQLEngine:
         if self._clarifier is not None and retry_count == 0:
             clarity = self._clarifier.analyze(question, conversation_history=conversation_history)
             if clarity.is_ambiguous:
-                logger.info("NL2SQL Clarification benötigt für: %s (confidence=%.2f)", question, clarity.confidence)
+                logger.info(
+                    "NL2SQL Clarification benötigt für: %s (confidence=%.2f)",
+                    question,
+                    clarity.confidence,
+                )
                 return NL2SQLResult(
                     success=False,
                     needs_clarification=True,
@@ -515,17 +553,23 @@ class NL2SQLEngine:
                 if hints.domain:
                     logger.debug(
                         "NL2SQL Semantic: domain=%s conf=%.0f%% matches=%d",
-                        hints.domain, hints.domain_confidence * 100,
+                        hints.domain,
+                        hints.domain_confidence * 100,
                         len(hints.glossary_matches),
                     )
             except Exception as e:
                 logger.warning("SemanticBridge Fehler (non-fatal): %s", e)
 
-        system_prompt = SYSTEM_PROMPT_TEMPLATE.format(
-            blocked_tables=", ".join(sorted(blocked)),
-            max_rows=source.max_rows,
-            schema_xml=source.schema_xml,
-        ) + few_shot + antipatterns + semantic_block
+        system_prompt = (
+            SYSTEM_PROMPT_TEMPLATE.format(
+                blocked_tables=", ".join(sorted(blocked)),
+                max_rows=source.max_rows,
+                schema_xml=source.schema_xml,
+            )
+            + few_shot
+            + antipatterns
+            + semantic_block
+        )
 
         messages = [{"role": "system", "content": system_prompt}]
         for h in conversation_history:
@@ -561,7 +605,9 @@ class NL2SQLEngine:
         if raw_sql is None:
             if "CANNOT_ANSWER" in llm_result.content.upper():
                 self._capture_feedback(
-                    source, question, "CANNOT_ANSWER",
+                    source,
+                    question,
+                    "CANNOT_ANSWER",
                     f"LLM konnte keine SQL-Antwort generieren. Frage evtl. außerhalb Schema-Scope. "
                     f"Semantic hints: {semantic_block[:200] if semantic_block else 'keine'}",
                 )
@@ -575,7 +621,9 @@ class NL2SQLEngine:
                     generation=generation,
                 )
             self._capture_feedback(
-                source, question, llm_result.content[:500],
+                source,
+                question,
+                llm_result.content[:500],
                 f"LLM hat kein gültiges SQL generiert sondern: {llm_result.content[:200]}",
             )
             hint, suggestions = _build_user_hint("NL2SQLGenerationError", "", question)
@@ -590,7 +638,9 @@ class NL2SQLEngine:
 
         validation_error = _validate_sql(raw_sql, blocked)
         if validation_error:
-            hint, suggestions = _build_user_hint("NL2SQLValidationError", validation_error, question)
+            hint, suggestions = _build_user_hint(
+                "NL2SQLValidationError", validation_error, question
+            )
             return NL2SQLResult(
                 success=False,
                 sql=raw_sql,
@@ -618,17 +668,22 @@ class NL2SQLEngine:
                 logger.info("NL2SQL Retry mit Fehler-Kontext für: %s", question)
                 retry_history = conversation_history + [
                     {"role": "assistant", "content": raw_sql},
-                    {"role": "user", "content": (
-                        f"Das SQL hat einen Fehler: {err_str}\n"
-                        "Bitte korrigiere das SQL. "
-                        "Wichtig: Verwende PostgreSQL-Syntax (INTERVAL '7 days' nicht INTERVAL 7 DAY). "
-                        "Prüfe die Join-Hints im Schema sorgfältig "
-                        "und verwende nur Felder die dort explizit aufgelistet sind."
-                    )},
+                    {
+                        "role": "user",
+                        "content": (
+                            f"Das SQL hat einen Fehler: {err_str}\n"
+                            "Bitte korrigiere das SQL. "
+                            "Wichtig: Verwende PostgreSQL-Syntax (INTERVAL '7 days' nicht INTERVAL 7 DAY). "
+                            "Prüfe die Join-Hints im Schema sorgfältig "
+                            "und verwende nur Felder die dort explizit aufgelistet sind."
+                        ),
+                    },
                 ]
                 return self._run(
-                    question, retry_history,
-                    retry_count=1, _first_feedback_pk=feedback_pk,
+                    question,
+                    retry_history,
+                    retry_count=1,
+                    _first_feedback_pk=feedback_pk,
                 )
 
             hint, suggestions = _build_user_hint("NL2SQLExecutionError", err_str, question)
@@ -662,7 +717,10 @@ class NL2SQLEngine:
 
         if retry_count > 0 and _first_feedback_pk is not None:
             self._auto_promote_correction(
-                _first_feedback_pk, source, question, raw_sql,
+                _first_feedback_pk,
+                source,
+                question,
+                raw_sql,
             )
 
         return NL2SQLResult(

--- a/src/aifw/nl2sql/management/commands/promote_feedback.py
+++ b/src/aifw/nl2sql/management/commands/promote_feedback.py
@@ -10,6 +10,7 @@ Usage:
     python manage.py promote_feedback --min-age-hours 1
     python manage.py promote_feedback --dry-run
 """
+
 from __future__ import annotations
 
 from datetime import timedelta
@@ -70,18 +71,14 @@ class Command(BaseCommand):
             ).exists()
 
             if exists:
-                self.stdout.write(
-                    self.style.WARNING(f"  SKIP (Duplicate): {fb.question[:60]}")
-                )
+                self.stdout.write(self.style.WARNING(f"  SKIP (Duplicate): {fb.question[:60]}"))
                 if not dry_run:
                     fb.promoted = True
                     fb.save(update_fields=["promoted"])
                 skipped_count += 1
                 continue
 
-            self.stdout.write(
-                f"  ✓ [{fb.source.code}] [{fb.error_type}] {fb.question[:60]}"
-            )
+            self.stdout.write(f"  ✓ [{fb.source.code}] [{fb.error_type}] {fb.question[:60]}")
 
             if not dry_run:
                 NL2SQLExample.objects.create(

--- a/src/aifw/nl2sql/management/commands/seed_nl2sql_examples.py
+++ b/src/aifw/nl2sql/management/commands/seed_nl2sql_examples.py
@@ -9,6 +9,7 @@ Usage:
     python manage.py seed_nl2sql_examples --source odoo_mfg
     python manage.py seed_nl2sql_examples --clear
 """
+
 from __future__ import annotations
 
 from django.core.management.base import BaseCommand
@@ -205,9 +206,7 @@ class Command(BaseCommand):
         skipped_count = 0
 
         for ex in examples:
-            exists = NL2SQLExample.objects.filter(
-                source=source, question=ex["question"]
-            ).exists()
+            exists = NL2SQLExample.objects.filter(source=source, question=ex["question"]).exists()
             if exists:
                 skipped_count += 1
                 continue
@@ -221,7 +220,7 @@ class Command(BaseCommand):
                 is_active=True,
             )
             created_count += 1
-            self.stdout.write(f"  ✓ [{ex.get('domain','')}] {ex['question'][:60]}")
+            self.stdout.write(f"  ✓ [{ex.get('domain', '')}] {ex['question'][:60]}")
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/src/aifw/nl2sql/management/commands/validate_schema.py
+++ b/src/aifw/nl2sql/management/commands/validate_schema.py
@@ -11,6 +11,7 @@ Usage:
     python manage.py validate_schema --source odoo_mfg
     python manage.py validate_schema --fix-hints
 """
+
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
@@ -20,6 +21,7 @@ from django.core.management.base import BaseCommand
 
 def _get_db_columns(db_alias: str, table_name: str) -> set[str]:
     from django.db import connections
+
     conn = connections[db_alias]
     with conn.cursor() as cur:
         cur.execute(
@@ -32,6 +34,7 @@ def _get_db_columns(db_alias: str, table_name: str) -> set[str]:
 
 def _get_db_tables(db_alias: str) -> set[str]:
     from django.db import connections
+
     conn = connections[db_alias]
     with conn.cursor() as cur:
         cur.execute(
@@ -67,9 +70,9 @@ class Command(BaseCommand):
         total_warnings = 0
 
         for source in qs:
-            self.stdout.write(f"\n{'='*60}")
+            self.stdout.write(f"\n{'=' * 60}")
             self.stdout.write(f"Source: {source.code} (DB: {source.db_alias})")
-            self.stdout.write("="*60)
+            self.stdout.write("=" * 60)
 
             errors = []
             warnings = []
@@ -114,9 +117,7 @@ class Command(BaseCommand):
                     if not col_name:
                         continue
                     if col_name not in db_cols:
-                        errors.append(
-                            f"Spalte '{table_name}.{col_name}' existiert NICHT in DB"
-                        )
+                        errors.append(f"Spalte '{table_name}.{col_name}' existiert NICHT in DB")
                         self.stdout.write(
                             self.style.ERROR(f"    ✗ Spalte '{col_name}' — nicht in DB")
                         )
@@ -134,7 +135,7 @@ class Command(BaseCommand):
             total_errors += len(errors)
             total_warnings += len(warnings)
 
-        self.stdout.write(f"\n{'='*60}")
+        self.stdout.write(f"\n{'=' * 60}")
         if total_errors == 0:
             self.stdout.write(
                 self.style.SUCCESS(

--- a/src/aifw/nl2sql/models.py
+++ b/src/aifw/nl2sql/models.py
@@ -5,6 +5,7 @@ SchemaSource:    Named DB target + XML schema for NL2SQL generation.
 NL2SQLExample:   Verified Q→SQL pairs injected as few-shot into LLM prompt.
 NL2SQLFeedback:  Auto-captured SQL errors + manual corrections pipeline.
 """
+
 from __future__ import annotations
 
 from django.db import models
@@ -36,8 +37,11 @@ class SchemaSource(models.Model):
 
     def get_blocked_tables_set(self) -> set[str]:
         always_blocked = {
-            "auth_user", "auth_token", "django_session",
-            "authtoken_token", "oauth2_provider_accesstoken",
+            "auth_user",
+            "auth_token",
+            "django_session",
+            "authtoken_token",
+            "oauth2_provider_accesstoken",
             "res_users_keys",
         }
         custom = {t.strip().lower() for t in self.blocked_tables.split(",") if t.strip()}
@@ -116,14 +120,14 @@ class NL2SQLFeedback(models.Model):
     """
 
     ERROR_TYPE_CHOICES = [
-        ("schema_error",     "Schema-Fehler (halluziniertes Feld)"),
-        ("table_error",      "Tabellen-Fehler (halluzinierte Tabelle)"),
-        ("join_error",       "Join-Fehler (falscher Join-Pfad)"),
-        ("syntax_error",     "Syntax-Fehler"),
-        ("cannot_answer",    "CANNOT_ANSWER (Frage außerhalb Schema-Scope)"),
+        ("schema_error", "Schema-Fehler (halluziniertes Feld)"),
+        ("table_error", "Tabellen-Fehler (halluzinierte Tabelle)"),
+        ("join_error", "Join-Fehler (falscher Join-Pfad)"),
+        ("syntax_error", "Syntax-Fehler"),
+        ("cannot_answer", "CANNOT_ANSWER (Frage außerhalb Schema-Scope)"),
         ("generation_error", "Generierungs-Fehler (kein valides SQL)"),
-        ("timeout",          "Timeout"),
-        ("unknown",          "Unbekannt"),
+        ("timeout", "Timeout"),
+        ("unknown", "Unbekannt"),
     ]
 
     source = models.ForeignKey(

--- a/src/aifw/nl2sql/results.py
+++ b/src/aifw/nl2sql/results.py
@@ -1,6 +1,7 @@
 """
 aifw.nl2sql.results — Result dataclasses for NL2SQLEngine.ask().
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/aifw/nl2sql/semantic.py
+++ b/src/aifw/nl2sql/semantic.py
@@ -21,6 +21,7 @@ Usage::
     # hints.semantic_context = "kaputt → state='breakdown'"
     # hints.temporal = None
 """
+
 from __future__ import annotations
 
 import re
@@ -28,33 +29,37 @@ from dataclasses import dataclass, field
 
 # ── Data Classes (Django-free) ──────────────────────────────────────────────
 
+
 @dataclass
 class GlossaryEntry:
     """Single term → schema mapping."""
-    term: str                    # "kaputt", "Ausschuss", "Lieferant"
-    target_column: str           # "state", "total_scrap_pct", "supplier_rank"
-    target_table: str            # "casting_machine", "casting_order", "res_partner"
-    sql_hint: str                # "state = 'breakdown'", "> 0"
-    category: str = "synonym"    # synonym | filter | aggregate | temporal
+
+    term: str  # "kaputt", "Ausschuss", "Lieferant"
+    target_column: str  # "state", "total_scrap_pct", "supplier_rank"
+    target_table: str  # "casting_machine", "casting_order", "res_partner"
+    sql_hint: str  # "state = 'breakdown'", "> 0"
+    category: str = "synonym"  # synonym | filter | aggregate | temporal
     language: str = "de"
 
 
 @dataclass
 class TemporalHint:
     """Parsed temporal expression → SQL fragment."""
-    original: str                # "diese Woche"
-    sql_fragment: str            # "BETWEEN CURRENT_DATE - INTERVAL '7 days' AND CURRENT_DATE"
-    column_hint: str = ""        # "date_planned" (suggested column)
+
+    original: str  # "diese Woche"
+    sql_fragment: str  # "BETWEEN CURRENT_DATE - INTERVAL '7 days' AND CURRENT_DATE"
+    column_hint: str = ""  # "date_planned" (suggested column)
 
 
 @dataclass
 class SemanticHints:
     """Result of semantic analysis — injected into LLM prompt."""
+
     domain: str | None = None
     domain_confidence: float = 0.0
     glossary_matches: list[GlossaryEntry] = field(default_factory=list)
     temporal: TemporalHint | None = None
-    semantic_context: str = ""   # Pre-formatted text block for prompt injection
+    semantic_context: str = ""  # Pre-formatted text block for prompt injection
 
     def to_prompt_block(self) -> str:
         """Format as text block for LLM system prompt injection."""
@@ -74,66 +79,150 @@ _DEFAULT_GLOSSARY: list[GlossaryEntry] = [
     GlossaryEntry("störung", "state", "casting_machine", "state = 'breakdown'", "filter"),
     GlossaryEntry("defekt", "state", "casting_machine", "state = 'breakdown'", "filter"),
     GlossaryEntry("wartung", "state", "casting_machine", "state = 'maintenance'", "filter"),
-    GlossaryEntry("ausschuss", "total_scrap_pct", "casting_order", "total_scrap_pct (Prozent)", "synonym"),
+    GlossaryEntry(
+        "ausschuss", "total_scrap_pct", "casting_order", "total_scrap_pct (Prozent)", "synonym"
+    ),
     GlossaryEntry("scrap", "total_scrap_pct", "casting_order", "total_scrap_pct", "synonym"),
-    GlossaryEntry("ausschussquote", "total_scrap_pct", "casting_order", "total_scrap_pct (Prozent)", "synonym"),
+    GlossaryEntry(
+        "ausschussquote", "total_scrap_pct", "casting_order", "total_scrap_pct (Prozent)", "synonym"
+    ),
     GlossaryEntry("gutteile", "good_qty", "casting_order_line", "good_qty (Stück)", "synonym"),
-    GlossaryEntry("legierung", "alloy_id", "casting_order_line",
-                   "FK → casting_alloy: JOIN casting_alloy ca ON ca.id = col.alloy_id", "synonym"),
+    GlossaryEntry(
+        "legierung",
+        "alloy_id",
+        "casting_order_line",
+        "FK → casting_alloy: JOIN casting_alloy ca ON ca.id = col.alloy_id",
+        "synonym",
+    ),
     GlossaryEntry("form", "mold_id", "casting_order_line", "FK → casting_mold", "synonym"),
-    GlossaryEntry("gießverfahren", "casting_process", "casting_order_line", "casting_process", "synonym"),
+    GlossaryEntry(
+        "gießverfahren", "casting_process", "casting_order_line", "casting_process", "synonym"
+    ),
     GlossaryEntry("halle", "hall", "casting_machine", "hall (Standort/Halle)", "synonym"),
     GlossaryEntry("storniert", "state", "casting_order", "state = 'cancelled'", "filter"),
     GlossaryEntry("abgeschlossen", "state", "casting_order", "state = 'done'", "filter"),
     GlossaryEntry("in produktion", "state", "casting_order", "state = 'in_production'", "filter"),
     GlossaryEntry("bestätigt", "state", "casting_order", "state = 'confirmed'", "filter"),
     GlossaryEntry("entwurf", "state", "casting_order", "state = 'draft'", "filter"),
-    GlossaryEntry("qualitätsprüfung", "result", "casting_quality_check", "result (pass/fail/conditional)", "synonym"),
-    GlossaryEntry("prüfung", "result", "casting_quality_check", "result (pass/fail/conditional)", "synonym"),
-
+    GlossaryEntry(
+        "qualitätsprüfung",
+        "result",
+        "casting_quality_check",
+        "result (pass/fail/conditional)",
+        "synonym",
+    ),
+    GlossaryEntry(
+        "prüfung", "result", "casting_quality_check", "result (pass/fail/conditional)", "synonym"
+    ),
     # ── Partner / Country ──
     GlossaryEntry("kunde", "customer_rank", "res_partner", "customer_rank > 0", "filter"),
     GlossaryEntry("kunden", "customer_rank", "res_partner", "customer_rank > 0", "filter"),
     GlossaryEntry("lieferant", "supplier_rank", "res_partner", "supplier_rank > 0", "filter"),
     GlossaryEntry("lieferanten", "supplier_rank", "res_partner", "supplier_rank > 0", "filter"),
-    GlossaryEntry("land", "country_id", "res_partner",
-                   "FK → res_country: JOIN res_country rc ON rc.id = rp.country_id → rc.name", "synonym"),
-    GlossaryEntry("länder", "country_id", "res_partner",
-                   "FK → res_country: JOIN res_country rc ON rc.id = rp.country_id → rc.name", "synonym"),
-
+    GlossaryEntry(
+        "land",
+        "country_id",
+        "res_partner",
+        "FK → res_country: JOIN res_country rc ON rc.id = rp.country_id → rc.name",
+        "synonym",
+    ),
+    GlossaryEntry(
+        "länder",
+        "country_id",
+        "res_partner",
+        "FK → res_country: JOIN res_country rc ON rc.id = rp.country_id → rc.name",
+        "synonym",
+    ),
     # ── SCM domain ──
     GlossaryEntry("bestellung", "id", "scm_purchase_order", "scm_purchase_order", "synonym"),
     GlossaryEntry("einkauf", "id", "scm_purchase_order", "scm_purchase_order", "synonym"),
-    GlossaryEntry("fertigungsauftrag", "id", "scm_production_order", "scm_production_order", "synonym"),
-    GlossaryEntry("produktionsauftrag", "id", "scm_production_order", "scm_production_order", "synonym"),
-    GlossaryEntry("ausbeute", "yield_pct", "scm_production_order", "yield_pct (Prozent)", "synonym"),
-    GlossaryEntry("überfällig", "date_planned", "casting_order",
-                   "date_planned < CURRENT_DATE AND state NOT IN ('done','cancelled')", "filter"),
+    GlossaryEntry(
+        "fertigungsauftrag", "id", "scm_production_order", "scm_production_order", "synonym"
+    ),
+    GlossaryEntry(
+        "produktionsauftrag", "id", "scm_production_order", "scm_production_order", "synonym"
+    ),
+    GlossaryEntry(
+        "ausbeute", "yield_pct", "scm_production_order", "yield_pct (Prozent)", "synonym"
+    ),
+    GlossaryEntry(
+        "überfällig",
+        "date_planned",
+        "casting_order",
+        "date_planned < CURRENT_DATE AND state NOT IN ('done','cancelled')",
+        "filter",
+    ),
     GlossaryEntry("fällig", "date_planned", "casting_order", "date_planned", "synonym"),
-
     # ── Stock / Inventory domain ──
-    GlossaryEntry("teil", "product_id", "stock_quant",
-                   "stock_quant JOIN product_product pp ON pp.id = sq.product_id JOIN product_template pt ON pt.id = pp.product_tmpl_id", "synonym"),
-    GlossaryEntry("teile", "product_id", "stock_quant",
-                   "stock_quant JOIN product_product pp ON pp.id = sq.product_id JOIN product_template pt ON pt.id = pp.product_tmpl_id", "synonym"),
-    GlossaryEntry("artikel", "product_id", "stock_quant",
-                   "stock_quant JOIN product_product → product_template", "synonym"),
-    GlossaryEntry("produkt", "name", "product_template",
-                   "product_template.name->>'en_US' (JSONB)", "synonym"),
-    GlossaryEntry("produkte", "name", "product_template",
-                   "product_template.name->>'en_US' (JSONB)", "synonym"),
-    GlossaryEntry("nullbestand", "quantity", "stock_quant",
-                   "quantity <= 0 (auf internen Lagerorten: stock_location.usage = 'internal')", "filter"),
-    GlossaryEntry("bestand", "quantity", "stock_quant",
-                   "SUM(quantity) GROUP BY product_id (nur stock_location.usage = 'internal')", "synonym"),
-    GlossaryEntry("lagerbestand", "quantity", "stock_quant",
-                   "SUM(quantity) über stock_quant WHERE stock_location.usage = 'internal'", "synonym"),
-    GlossaryEntry("kritisch", "product_min_qty", "stock_warehouse_orderpoint",
-                   "Bestand < product_min_qty (stock_warehouse_orderpoint)", "filter"),
-    GlossaryEntry("mindestbestand", "product_min_qty", "stock_warehouse_orderpoint",
-                   "product_min_qty in stock_warehouse_orderpoint", "synonym"),
-    GlossaryEntry("lagerort", "location_id", "stock_quant",
-                   "FK → stock_location: JOIN stock_location sl ON sl.id = sq.location_id → sl.complete_name", "synonym"),
+    GlossaryEntry(
+        "teil",
+        "product_id",
+        "stock_quant",
+        "stock_quant JOIN product_product pp ON pp.id = sq.product_id JOIN product_template pt ON pt.id = pp.product_tmpl_id",
+        "synonym",
+    ),
+    GlossaryEntry(
+        "teile",
+        "product_id",
+        "stock_quant",
+        "stock_quant JOIN product_product pp ON pp.id = sq.product_id JOIN product_template pt ON pt.id = pp.product_tmpl_id",
+        "synonym",
+    ),
+    GlossaryEntry(
+        "artikel",
+        "product_id",
+        "stock_quant",
+        "stock_quant JOIN product_product → product_template",
+        "synonym",
+    ),
+    GlossaryEntry(
+        "produkt", "name", "product_template", "product_template.name->>'en_US' (JSONB)", "synonym"
+    ),
+    GlossaryEntry(
+        "produkte", "name", "product_template", "product_template.name->>'en_US' (JSONB)", "synonym"
+    ),
+    GlossaryEntry(
+        "nullbestand",
+        "quantity",
+        "stock_quant",
+        "quantity <= 0 (auf internen Lagerorten: stock_location.usage = 'internal')",
+        "filter",
+    ),
+    GlossaryEntry(
+        "bestand",
+        "quantity",
+        "stock_quant",
+        "SUM(quantity) GROUP BY product_id (nur stock_location.usage = 'internal')",
+        "synonym",
+    ),
+    GlossaryEntry(
+        "lagerbestand",
+        "quantity",
+        "stock_quant",
+        "SUM(quantity) über stock_quant WHERE stock_location.usage = 'internal'",
+        "synonym",
+    ),
+    GlossaryEntry(
+        "kritisch",
+        "product_min_qty",
+        "stock_warehouse_orderpoint",
+        "Bestand < product_min_qty (stock_warehouse_orderpoint)",
+        "filter",
+    ),
+    GlossaryEntry(
+        "mindestbestand",
+        "product_min_qty",
+        "stock_warehouse_orderpoint",
+        "product_min_qty in stock_warehouse_orderpoint",
+        "synonym",
+    ),
+    GlossaryEntry(
+        "lagerort",
+        "location_id",
+        "stock_quant",
+        "FK → stock_location: JOIN stock_location sl ON sl.id = sq.location_id → sl.complete_name",
+        "synonym",
+    ),
     GlossaryEntry("artikelnummer", "default_code", "product_template", "default_code", "synonym"),
     GlossaryEntry("barcode", "barcode", "product_product", "barcode", "synonym"),
 ]
@@ -143,16 +232,44 @@ _DEFAULT_GLOSSARY: list[GlossaryEntry] = [
 
 _TEMPORAL_PATTERNS: list[tuple[str, str, str]] = [
     # (regex_pattern, sql_fragment, column_hint)
-    (r"diese[rnm]?\s+woche", "BETWEEN CURRENT_DATE - INTERVAL '7 days' AND CURRENT_DATE", "date_planned"),
-    (r"letzte[rnm]?\s+woche", "BETWEEN CURRENT_DATE - INTERVAL '14 days' AND CURRENT_DATE - INTERVAL '7 days'", "date_planned"),
-    (r"diese[rnm]?\s+monat", "BETWEEN date_trunc('month', CURRENT_DATE) AND CURRENT_DATE", "date_planned"),
-    (r"letzte[rnm]?\s+monat", "BETWEEN date_trunc('month', CURRENT_DATE) - INTERVAL '1 month' AND date_trunc('month', CURRENT_DATE) - INTERVAL '1 day'", "date_planned"),
+    (
+        r"diese[rnm]?\s+woche",
+        "BETWEEN CURRENT_DATE - INTERVAL '7 days' AND CURRENT_DATE",
+        "date_planned",
+    ),
+    (
+        r"letzte[rnm]?\s+woche",
+        "BETWEEN CURRENT_DATE - INTERVAL '14 days' AND CURRENT_DATE - INTERVAL '7 days'",
+        "date_planned",
+    ),
+    (
+        r"diese[rnm]?\s+monat",
+        "BETWEEN date_trunc('month', CURRENT_DATE) AND CURRENT_DATE",
+        "date_planned",
+    ),
+    (
+        r"letzte[rnm]?\s+monat",
+        "BETWEEN date_trunc('month', CURRENT_DATE) - INTERVAL '1 month' AND date_trunc('month', CURRENT_DATE) - INTERVAL '1 day'",
+        "date_planned",
+    ),
     (r"heute", "= CURRENT_DATE", "date_planned"),
     (r"gestern", "= CURRENT_DATE - INTERVAL '1 day'", "date_planned"),
-    (r"letzten?\s+(\d+)\s+tage?n?", "BETWEEN CURRENT_DATE - INTERVAL '{0} days' AND CURRENT_DATE", "date_planned"),
-    (r"letzten?\s+(\d+)\s+monat(?:e|en)?", "BETWEEN CURRENT_DATE - INTERVAL '{0} months' AND CURRENT_DATE", "date_planned"),
+    (
+        r"letzten?\s+(\d+)\s+tage?n?",
+        "BETWEEN CURRENT_DATE - INTERVAL '{0} days' AND CURRENT_DATE",
+        "date_planned",
+    ),
+    (
+        r"letzten?\s+(\d+)\s+monat(?:e|en)?",
+        "BETWEEN CURRENT_DATE - INTERVAL '{0} months' AND CURRENT_DATE",
+        "date_planned",
+    ),
     (r"dieses\s+jahr", "BETWEEN date_trunc('year', CURRENT_DATE) AND CURRENT_DATE", "create_date"),
-    (r"letztes\s+jahr", "BETWEEN date_trunc('year', CURRENT_DATE) - INTERVAL '1 year' AND date_trunc('year', CURRENT_DATE) - INTERVAL '1 day'", "create_date"),
+    (
+        r"letztes\s+jahr",
+        "BETWEEN date_trunc('year', CURRENT_DATE) - INTERVAL '1 year' AND date_trunc('year', CURRENT_DATE) - INTERVAL '1 day'",
+        "create_date",
+    ),
 ]
 
 
@@ -160,27 +277,73 @@ _TEMPORAL_PATTERNS: list[tuple[str, str, str]] = [
 
 _DOMAIN_KEYWORDS: dict[str, list[str]] = {
     "casting": [
-        "maschine", "maschinen", "gieß", "guss", "gießerei", "form", "legierung",
-        "auftrag", "aufträge", "ausschuss", "qualität", "prüfung", "halle",
-        "störung", "kaputt", "wartung", "casting", "mold",
+        "maschine",
+        "maschinen",
+        "gieß",
+        "guss",
+        "gießerei",
+        "form",
+        "legierung",
+        "auftrag",
+        "aufträge",
+        "ausschuss",
+        "qualität",
+        "prüfung",
+        "halle",
+        "störung",
+        "kaputt",
+        "wartung",
+        "casting",
+        "mold",
     ],
     "scm": [
-        "bestellung", "einkauf", "lieferant", "lieferung",
-        "fertigung", "produktion", "bom", "stückliste", "purchase",
+        "bestellung",
+        "einkauf",
+        "lieferant",
+        "lieferung",
+        "fertigung",
+        "produktion",
+        "bom",
+        "stückliste",
+        "purchase",
     ],
     "stock": [
-        "teil", "teile", "artikel", "produkt", "produkte", "lager", "bestand",
-        "nullbestand", "lagerbestand", "lagerort", "kritisch", "mindestbestand",
-        "barcode", "artikelnummer", "vorrat", "inventory", "stock", "warehouse",
+        "teil",
+        "teile",
+        "artikel",
+        "produkt",
+        "produkte",
+        "lager",
+        "bestand",
+        "nullbestand",
+        "lagerbestand",
+        "lagerort",
+        "kritisch",
+        "mindestbestand",
+        "barcode",
+        "artikelnummer",
+        "vorrat",
+        "inventory",
+        "stock",
+        "warehouse",
     ],
     "base": [
-        "kunde", "kunden", "partner", "land", "länder", "firma", "unternehmen",
-        "kontakt", "email", "telefon",
+        "kunde",
+        "kunden",
+        "partner",
+        "land",
+        "länder",
+        "firma",
+        "unternehmen",
+        "kontakt",
+        "email",
+        "telefon",
     ],
 }
 
 
 # ── SemanticBridge ───────────────────────────────────────────────────────────
+
 
 class SemanticBridge:
     """Bridges natural language to DB schema semantics.
@@ -215,6 +378,7 @@ class SemanticBridge:
         """Load additional glossary entries from DB (if available). Returns count added."""
         try:
             from aifw.nl2sql.models import SchemaSource
+
             source = SchemaSource.objects.filter(code=source_code, is_active=True).first()
             if source and hasattr(source, "glossary_entries"):
                 # Future: DB-backed SemanticGlossary model
@@ -290,15 +454,17 @@ class SemanticBridge:
         parts: list[str] = []
 
         if hints.domain:
-            parts.append(f"- Erkannte Domäne: {hints.domain} (Konfidenz: {hints.domain_confidence:.0%})")
+            parts.append(
+                f"- Erkannte Domäne: {hints.domain} (Konfidenz: {hints.domain_confidence:.0%})"
+            )
 
         if hints.glossary_matches:
             for g in hints.glossary_matches:
-                parts.append(f"- \"{g.term}\" → {g.target_table}.{g.target_column}: {g.sql_hint}")
+                parts.append(f'- "{g.term}" → {g.target_table}.{g.target_column}: {g.sql_hint}')
 
         if hints.temporal:
             parts.append(
-                f"- Zeitbezug \"{hints.temporal.original}\" → "
+                f'- Zeitbezug "{hints.temporal.original}" → '
                 f"{hints.temporal.column_hint} {hints.temporal.sql_fragment}"
             )
 

--- a/src/aifw/privacy.py
+++ b/src/aifw/privacy.py
@@ -27,6 +27,7 @@ The ``AIFW_PRIVACY_HMAC_SECRET`` setting keys the pseudonymous user hash; it fal
 back to Django's ``SECRET_KEY`` when unset. ``aifw`` never imports ``iil-promptfw`` —
 topic classification is a plain callable injected by the consumer.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -44,8 +45,10 @@ logger = logging.getLogger(__name__)
 # Settings access (read fresh every call — override_settings must take effect)
 # ---------------------------------------------------------------------------
 
+
 def _get_setting(name: str, default: Any = None) -> Any:
     from django.conf import settings
+
     return getattr(settings, name, default)
 
 
@@ -60,6 +63,7 @@ def _hmac_user(user_pk: Any, secret: bytes) -> str:
 
 def _today_iso() -> str:
     from django.utils import timezone
+
     return timezone.now().date().isoformat()
 
 
@@ -76,6 +80,7 @@ def _default_topic_classifier(nl_question: str) -> str:
 # ---------------------------------------------------------------------------
 # Hook implementations
 # ---------------------------------------------------------------------------
+
 
 class PrivacyHook:
     """Base hook — ``full`` mode: identity transform (writes payload raw)."""
@@ -139,6 +144,7 @@ _BUILTIN_HOOKS: dict[str, type[PrivacyHook]] = {
 # Resolution
 # ---------------------------------------------------------------------------
 
+
 def _import_hook(dotted: str) -> PrivacyHook:
     """Import a custom hook from ``"module:attr"`` or ``"module.attr"``."""
     if ":" in dotted:
@@ -159,9 +165,7 @@ def _import_hook(dotted: str) -> PrivacyHook:
             f"AIFW_PRIVACY_HOOK {dotted!r} factory returned {type(result).__name__}, "
             f"expected a PrivacyHook"
         )
-    raise TypeError(
-        f"AIFW_PRIVACY_HOOK {dotted!r} is neither a PrivacyHook, subclass, nor factory"
-    )
+    raise TypeError(f"AIFW_PRIVACY_HOOK {dotted!r} is neither a PrivacyHook, subclass, nor factory")
 
 
 def get_privacy_hook() -> PrivacyHook:
@@ -177,9 +181,7 @@ def get_privacy_hook() -> PrivacyHook:
 
     mode = _get_setting("AIFW_PRIVACY_MODE", PrivacyMode.FULL)
     if not PrivacyMode.is_valid(mode):
-        logger.warning(
-            "Invalid AIFW_PRIVACY_MODE %r — falling back to 'full'", mode
-        )
+        logger.warning("Invalid AIFW_PRIVACY_MODE %r — falling back to 'full'", mode)
         mode = PrivacyMode.FULL
     return _BUILTIN_HOOKS[mode]()
 
@@ -200,9 +202,7 @@ def apply_privacy(payload: dict[str, Any]) -> dict[str, Any]:
         intended = _get_setting("AIFW_PRIVACY_MODE", PrivacyMode.FULL)
         custom = bool(_get_setting("AIFW_PRIVACY_HOOK"))
         if custom or intended != PrivacyMode.FULL:
-            logger.warning(
-                "Privacy hook failed (%s) — failing closed, scrubbing PII", exc
-            )
+            logger.warning("Privacy hook failed (%s) — failing closed, scrubbing PII", exc)
             payload["user"] = None
             payload["metadata"] = {"privacy_error": True}
             payload["privacy_mode"] = (

--- a/src/aifw/schema.py
+++ b/src/aifw/schema.py
@@ -79,11 +79,13 @@ class LLMResult:
         """
         try:
             from promptfw.parsing import extract_json
+
             return extract_json(self.content)
         except ImportError:
             pass
         import json
         import re
+
         text = self.content.strip()
         match = re.search(r"```(?:json)?\s*([\s\S]+?)\s*```", text)
         if match:
@@ -106,6 +108,7 @@ class LLMResult:
             premise = result.field("Premise", default="")
         """
         import re
+
         pattern = re.compile(
             r"(?:^|\n)\s*\*{0,2}" + re.escape(name) + r"(?:\*{0,2})?:(?:\*{0,2})?[ \t]*(.+)",
             re.IGNORECASE,

--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -20,6 +20,7 @@ New in 0.4.0:
 - sync_completion_stream with queue.Queue (true streaming)
 - RenderedPromptProtocol replaces duck-typing
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -83,6 +84,7 @@ def _local_set(key: str, value: Any) -> None:
 def _shared_get(key: str) -> Any | None:
     try:
         from django.core.cache import cache
+
         return cache.get(key)
     except Exception:
         return None
@@ -91,6 +93,7 @@ def _shared_get(key: str) -> Any | None:
 def _shared_set(key: str, value: Any) -> None:
     try:
         from django.core.cache import cache
+
         cache.set(key, value, timeout=_SHARED_TTL)
     except Exception:
         pass  # graceful — local cache is sufficient
@@ -99,6 +102,7 @@ def _shared_set(key: str, value: Any) -> None:
 def _shared_delete_many(keys: list[str]) -> None:
     try:
         from django.core.cache import cache
+
         cache.delete_many(keys)
     except Exception:
         pass
@@ -125,6 +129,7 @@ def _cache_set(key: str, value: Any) -> None:
 # Cache key helpers
 # ---------------------------------------------------------------------------
 
+
 def _action_cache_key(code: str, quality_level: int | None, priority: str | None) -> str:
     ql = str(quality_level) if quality_level is not None else "_"
     prio = priority if priority is not None else "_"
@@ -150,9 +155,7 @@ def _tier_cache_key(tier: str) -> str:
     return f"aifw:tier:{tier}"
 
 
-def _completion_cache_key(
-    code: str, quality_level: int | None, priority: str | None
-) -> str:
+def _completion_cache_key(code: str, quality_level: int | None, priority: str | None) -> str:
     """Cache key for the resolved completion config (distinct from the
     ActionConfig key used by get_action_config to avoid a shape collision)."""
     ql = str(quality_level) if quality_level is not None else "_"
@@ -163,6 +166,7 @@ def _completion_cache_key(
 # ---------------------------------------------------------------------------
 # Cache invalidation (public API)
 # ---------------------------------------------------------------------------
+
 
 def invalidate_action_cache(action_code: str | None = None) -> None:
     """Invalidate action config cache.
@@ -179,6 +183,7 @@ def invalidate_action_cache(action_code: str | None = None) -> None:
         _LOCAL_CACHE.clear()
         try:
             from django.core.cache import cache
+
             cache.clear()
         except Exception:
             pass
@@ -210,6 +215,7 @@ def invalidate_config_cache(action_code: str | None = None) -> None:
 # Core lookup: 4-step cascade (ADR-097 §5.1)
 # ---------------------------------------------------------------------------
 
+
 def _lookup_cascade(
     code: str,
     quality_level: int | None,
@@ -233,32 +239,24 @@ def _lookup_cascade(
 
     # Step 1: exact match
     if quality_level is not None and priority is not None:
-        row = base_qs.filter(
-            quality_level=quality_level, priority=priority
-        ).first()
+        row = base_qs.filter(quality_level=quality_level, priority=priority).first()
         if row:
             return row
 
     # Step 2: quality_level only
     if quality_level is not None:
-        row = base_qs.filter(
-            quality_level=quality_level, priority__isnull=True
-        ).first()
+        row = base_qs.filter(quality_level=quality_level, priority__isnull=True).first()
         if row:
             return row
 
     # Step 3: priority only
     if priority is not None:
-        row = base_qs.filter(
-            quality_level__isnull=True, priority=priority
-        ).first()
+        row = base_qs.filter(quality_level__isnull=True, priority=priority).first()
         if row:
             return row
 
     # Step 4: catch-all
-    row = base_qs.filter(
-        quality_level__isnull=True, priority__isnull=True
-    ).first()
+    row = base_qs.filter(quality_level__isnull=True, priority__isnull=True).first()
     if row:
         return row
 
@@ -279,6 +277,7 @@ def _to_action_config(action: "AIActionType") -> ActionConfig:  # type: ignore[n
             f"Check default_model and fallback_model configuration."
         )
     from aifw.service import _build_model_string
+
     ms = _build_model_string(model.provider.name, model.name)
     return ActionConfig(
         action_id=action.id,
@@ -298,6 +297,7 @@ def _to_action_config(action: "AIActionType") -> ActionConfig:  # type: ignore[n
 # ---------------------------------------------------------------------------
 # Public: get_action_config (ADR-097 §5.2)
 # ---------------------------------------------------------------------------
+
 
 def get_action_config(
     action_code: str,
@@ -335,6 +335,7 @@ def get_action_config(
 # Public: get_quality_level_for_tier (ADR-097 §5.3)
 # ---------------------------------------------------------------------------
 
+
 def get_quality_level_for_tier(tier: str | None) -> int:
     """Resolve quality_level for a subscription tier name.
 
@@ -355,9 +356,8 @@ def get_quality_level_for_tier(tier: str | None) -> int:
 
     try:
         from aifw.models import TierQualityMapping
-        mapping = TierQualityMapping.objects.filter(
-            tier=tier, is_active=True
-        ).first()
+
+        mapping = TierQualityMapping.objects.filter(tier=tier, is_active=True).first()
         result = mapping.quality_level if mapping else QualityLevel.BALANCED
     except Exception as exc:
         logger.warning("get_quality_level_for_tier(%r) DB error: %s", tier, exc)
@@ -388,9 +388,7 @@ try:
             Timeout,
         )
 
-        _TRANSIENT_ERRORS = (
-            RateLimitError, ServiceUnavailableError, Timeout, APIConnectionError
-        )
+        _TRANSIENT_ERRORS = (RateLimitError, ServiceUnavailableError, Timeout, APIConnectionError)
     except ImportError:
         _TRANSIENT_ERRORS = (Exception,)  # type: ignore[assignment]
 
@@ -422,6 +420,7 @@ async def _acompletion_with_retry(**kwargs: Any) -> Any:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
 
 def _build_model_string(provider_name: str, model_name: str) -> str:
     provider = provider_name.lower()
@@ -492,9 +491,7 @@ def _rendered_prompt_to_overrides(rendered) -> dict[str, Any]:
     elif rf == "json_schema":
         schema = getattr(rendered, "output_schema", None)
         if schema:
-            overrides["response_format"] = {
-                "type": "json_schema", "json_schema": schema
-            }
+            overrides["response_format"] = {"type": "json_schema", "json_schema": schema}
         else:
             overrides["response_format"] = {"type": "json_object"}
     return overrides
@@ -565,12 +562,11 @@ def _build_kwargs(
 # Legacy: get_model_config (backwards-compatible wrapper)
 # ---------------------------------------------------------------------------
 
+
 def _with_api_key(cfg: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of a cached config with the api_key resolved fresh."""
     cfg = dict(cfg)
-    cfg["api_key"] = _resolve_api_key(
-        cfg.get("provider_name", ""), cfg.get("api_key_env_var", "")
-    )
+    cfg["api_key"] = _resolve_api_key(cfg.get("provider_name", ""), cfg.get("api_key_env_var", ""))
     return cfg
 
 
@@ -613,9 +609,7 @@ async def get_model_config(
             model = await sync_to_async(action.get_model)()
             if model and model.provider:
                 cfg = {
-                    "model_string": _build_model_string(
-                        model.provider.name, model.name
-                    ),
+                    "model_string": _build_model_string(model.provider.name, model.name),
                     "api_base": model.provider.base_url or None,
                     "api_key_env_var": model.provider.api_key_env_var or "",
                     "max_tokens": action.max_tokens,
@@ -630,9 +624,11 @@ async def get_model_config(
 
         # No routed row for this code → global default model (legacy 0.5.x).
         global_default = await sync_to_async(
-            lambda: LLMModel.objects.select_related("provider")
-            .filter(is_default=True, is_active=True)
-            .first()
+            lambda: (
+                LLMModel.objects.select_related("provider")
+                .filter(is_default=True, is_active=True)
+                .first()
+            )
         )()
 
         if global_default and global_default.provider:
@@ -672,6 +668,7 @@ async def get_model_config(
 # Internal usage logger
 # ---------------------------------------------------------------------------
 
+
 async def _log_usage(
     config: dict[str, Any],
     result: LLMResult,
@@ -694,9 +691,7 @@ async def _log_usage(
                 lambda: AIActionType.objects.filter(id=action_id).first()
             )()
         if model_id:
-            model = await sync_to_async(
-                lambda: LLMModel.objects.filter(id=model_id).first()
-            )()
+            model = await sync_to_async(lambda: LLMModel.objects.filter(id=model_id).first())()
 
         if isinstance(tenant_id, str):
             try:
@@ -711,6 +706,7 @@ async def _log_usage(
         estimated_cost = 0.0
         if model:
             from aifw.cost import cost_from_rates
+
             estimated_cost = cost_from_rates(
                 result.input_tokens,
                 result.output_tokens,
@@ -751,6 +747,7 @@ async def _log_usage(
 # ---------------------------------------------------------------------------
 # Core async completion
 # ---------------------------------------------------------------------------
+
 
 async def completion(
     action_code: str,
@@ -1004,9 +1001,11 @@ async def completion_with_fallback(
         from aifw.models import AIActionType
 
         action = await sync_to_async(
-            lambda: AIActionType.objects.select_related("fallback_model__provider")
-            .filter(code=action_code, is_active=True)
-            .first()
+            lambda: (
+                AIActionType.objects.select_related("fallback_model__provider")
+                .filter(code=action_code, is_active=True)
+                .first()
+            )
         )()
         if action and action.fallback_model and action.fallback_model.is_active:
             fb = action.fallback_model
@@ -1082,9 +1081,8 @@ def check_action_code(action_code: str) -> bool:
     """Return True if action_code has at least one active row (any quality_level/priority)."""
     try:
         from aifw.models import AIActionType
-        exists = AIActionType.objects.filter(
-            code=action_code, is_active=True
-        ).exists()
+
+        exists = AIActionType.objects.filter(code=action_code, is_active=True).exists()
         if not exists:
             logger.warning(
                 "aifw: action_code '%s' not found — run 'manage.py init_aifw_config'",

--- a/src/aifw/signals.py
+++ b/src/aifw/signals.py
@@ -8,6 +8,7 @@ LLMModel, LLMProvider, or TierQualityMapping records are saved or deleted.
 For multi-worker Gunicorn deployments: configure CACHES to use Redis in the
 consumer app. The process-local cache provides an additional 30s buffer.
 """
+
 from __future__ import annotations
 
 from django.db.models.signals import post_delete, post_save

--- a/src/aifw/types.py
+++ b/src/aifw/types.py
@@ -6,6 +6,7 @@ ADR-097 §5.2 — ActionConfig shape.  0.9.0: added model_string alias.
 Consumers (authoringfw, bfagent, etc.) depend on this contract.
 Changes to ActionConfig are breaking changes requiring a minor version bump.
 """
+
 from __future__ import annotations
 
 from typing import TypedDict
@@ -27,10 +28,10 @@ class ActionConfig(TypedDict):
     action_id: int
     action_code: str
     model_id: int
-    model: str            # LiteLLM model string e.g. "gpt-4o", "anthropic/claude-3-5-sonnet"
-    model_string: str     # Alias of model — used by _build_kwargs and legacy callers
-    provider: str         # Provider name e.g. "openai", "anthropic"
-    base_url: str         # Provider base URL (empty string if not set)
+    model: str  # LiteLLM model string e.g. "gpt-4o", "anthropic/claude-3-5-sonnet"
+    model_string: str  # Alias of model — used by _build_kwargs and legacy callers
+    provider: str  # Provider name e.g. "openai", "anthropic"
+    base_url: str  # Provider base URL (empty string if not set)
     api_key_env_var: str  # Env var name holding the API key
     prompt_template_key: str | None  # promptfw key or None; caller uses action_code as fallback
     max_tokens: int

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
 """Tests for aifw cache invalidation (ADR-097 G-097-02/03)."""
+
 from unittest.mock import MagicMock, patch
 
 from aifw.service import (
@@ -13,6 +14,7 @@ from aifw.service import (
 )
 
 # ── Cache key helpers ─────────────────────────────────────────────────────────
+
 
 def test_should_build_action_cache_key_with_both_params():
     key = _action_cache_key("write", 5, "quality")
@@ -39,6 +41,7 @@ def test_should_generate_all_keys_for_code():
 
 # ── Local cache get/set ───────────────────────────────────────────────────────
 
+
 def test_should_store_and_retrieve_from_local_cache():
     _LOCAL_CACHE.clear()
     _cache_set("test:key", {"value": 42})
@@ -54,6 +57,7 @@ def test_should_return_none_for_missing_cache_key():
 
 
 # ── invalidate_action_cache ───────────────────────────────────────────────────
+
 
 def test_should_clear_specific_action_from_local_cache():
     _LOCAL_CACHE.clear()
@@ -90,6 +94,7 @@ def test_should_call_delete_many_not_delete_loop():
 
 
 # ── invalidate_tier_cache ─────────────────────────────────────────────────────
+
 
 def test_should_clear_specific_tier_from_local_cache():
     _LOCAL_CACHE.clear()

--- a/tests/test_log_usage.py
+++ b/tests/test_log_usage.py
@@ -78,6 +78,7 @@ def success_result():
 # _log_usage DB write tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_should_write_tenant_id_to_usage_log(config, success_result):

--- a/tests/test_lookup_cascade.py
+++ b/tests/test_lookup_cascade.py
@@ -3,15 +3,18 @@
 All tests use pytest-django with @pytest.mark.django_db.
 No real LLM calls — DB only.
 """
+
 import pytest
 
 from aifw.exceptions import ConfigurationError
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
+
 @pytest.fixture()
 def provider(db):
     from aifw.models import LLMProvider
+
     return LLMProvider.objects.create(
         name="openai",
         api_key_env_var="OPENAI_API_KEY",
@@ -21,6 +24,7 @@ def provider(db):
 @pytest.fixture()
 def model(provider):
     from aifw.models import LLMModel
+
     return LLMModel.objects.create(
         name="gpt-4o",
         provider=provider,
@@ -31,6 +35,7 @@ def model(provider):
 def _action(code, model, quality_level=None, priority=None, is_active=True):
     """Helper: create an AIActionType row."""
     from aifw.models import AIActionType
+
     return AIActionType.objects.create(
         code=code,
         name=f"{code} ql={quality_level} prio={priority}",
@@ -45,13 +50,14 @@ def _action(code, model, quality_level=None, priority=None, is_active=True):
 
 # ── F-01: Exact match (ql + prio) ─────────────────────────────────────────────
 
+
 @pytest.mark.django_db
 def test_should_return_exact_match_when_both_ql_and_priority_match(model):
     """F-01: Exact (ql=5, prio=quality) row returned when both params set."""
     from aifw.service import _lookup_cascade
 
-    _action("write", model, quality_level=None, priority=None)   # catch-all
-    _action("write", model, quality_level=5, priority=None)       # ql-only
+    _action("write", model, quality_level=None, priority=None)  # catch-all
+    _action("write", model, quality_level=5, priority=None)  # ql-only
     exact = _action("write", model, quality_level=5, priority="quality")
 
     result = _lookup_cascade("write", quality_level=5, priority="quality")
@@ -60,12 +66,13 @@ def test_should_return_exact_match_when_both_ql_and_priority_match(model):
 
 # ── F-02: ql-only fallback ────────────────────────────────────────────────────
 
+
 @pytest.mark.django_db
 def test_should_fall_back_to_ql_only_when_no_exact_match(model):
     """F-02: ql-only row used when prio has no exact match."""
     from aifw.service import _lookup_cascade
 
-    _action("write", model, quality_level=None, priority=None)   # catch-all
+    _action("write", model, quality_level=None, priority=None)  # catch-all
     ql_only = _action("write", model, quality_level=5, priority=None)
 
     result = _lookup_cascade("write", quality_level=5, priority="quality")
@@ -74,12 +81,13 @@ def test_should_fall_back_to_ql_only_when_no_exact_match(model):
 
 # ── F-03: prio-only fallback ──────────────────────────────────────────────────
 
+
 @pytest.mark.django_db
 def test_should_fall_back_to_prio_only_when_no_ql_match(model):
     """F-03: prio-only row used when quality_level has no match."""
     from aifw.service import _lookup_cascade
 
-    _action("write", model, quality_level=None, priority=None)   # catch-all
+    _action("write", model, quality_level=None, priority=None)  # catch-all
     prio_only = _action("write", model, quality_level=None, priority="fast")
 
     result = _lookup_cascade("write", quality_level=5, priority="fast")
@@ -87,6 +95,7 @@ def test_should_fall_back_to_prio_only_when_no_ql_match(model):
 
 
 # ── F-04: catch-all fallback ──────────────────────────────────────────────────
+
 
 @pytest.mark.django_db
 def test_should_fall_back_to_catch_all_when_no_specific_match(model):
@@ -101,6 +110,7 @@ def test_should_fall_back_to_catch_all_when_no_specific_match(model):
 
 # ── F-05: raises ConfigurationError when no row at all ───────────────────────
 
+
 @pytest.mark.django_db
 def test_should_raise_configuration_error_when_no_row_exists(model):
     """F-05: ConfigurationError raised if no row for code at any step."""
@@ -111,6 +121,7 @@ def test_should_raise_configuration_error_when_no_row_exists(model):
 
 
 # ── F-06: inactive rows are ignored ──────────────────────────────────────────
+
 
 @pytest.mark.django_db
 def test_should_ignore_inactive_rows(model):
@@ -124,6 +135,7 @@ def test_should_ignore_inactive_rows(model):
 
 
 # ── F-07: step-1 skipped when quality_level is None ──────────────────────────
+
 
 @pytest.mark.django_db
 def test_should_skip_step1_when_quality_level_is_none(model):
@@ -140,6 +152,7 @@ def test_should_skip_step1_when_quality_level_is_none(model):
 
 # ── F-08: step-1 skipped when priority is None ───────────────────────────────
 
+
 @pytest.mark.django_db
 def test_should_skip_step1_when_priority_is_none(model):
     """F-08: step 1 (exact) skipped when priority=None."""
@@ -153,6 +166,7 @@ def test_should_skip_step1_when_priority_is_none(model):
 
 
 # ── F-09: step-3 skipped when priority is None ───────────────────────────────
+
 
 @pytest.mark.django_db
 def test_should_skip_step3_when_priority_is_none(model):
@@ -168,6 +182,7 @@ def test_should_skip_step3_when_priority_is_none(model):
 
 # ── F-10: catch-all requires no-ql AND no-prio ───────────────────────────────
 
+
 @pytest.mark.django_db
 def test_should_not_use_row_with_ql_set_as_catch_all(model):
     """F-10: A row with quality_level set must not match as catch-all."""
@@ -181,6 +196,7 @@ def test_should_not_use_row_with_ql_set_as_catch_all(model):
 
 # ── F-11: multiple codes are isolated ────────────────────────────────────────
 
+
 @pytest.mark.django_db
 def test_should_isolate_rows_by_code(model):
     """F-11: Rows for code='other' must not match code='write'."""
@@ -193,6 +209,7 @@ def test_should_isolate_rows_by_code(model):
 
 
 # ── F-12: exact match preferred over ql-only ─────────────────────────────────
+
 
 @pytest.mark.django_db
 def test_should_prefer_exact_over_ql_only(model):
@@ -209,6 +226,7 @@ def test_should_prefer_exact_over_ql_only(model):
 
 
 # ── F-13: ql-only preferred over prio-only ───────────────────────────────────
+
 
 @pytest.mark.django_db
 def test_should_prefer_ql_only_over_prio_only(model):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -96,6 +96,7 @@ def test_usage_log_estimated_cost(action_type, model):
 @pytest.mark.django_db
 def test_usage_log_tenant_id_stored(action_type, model):
     import uuid
+
     tid = uuid.uuid4()
     log = AIUsageLog.objects.create(
         action_type=action_type,

--- a/tests/test_nl2sql_readonly.py
+++ b/tests/test_nl2sql_readonly.py
@@ -7,6 +7,7 @@ they assert the guard is *wired* (the statements issued, in order). The actual
 "cannot execute in a read-only transaction" rejection is a PostgreSQL behaviour
 and is not reproducible against the sqlite test DB.
 """
+
 from unittest.mock import patch
 
 from aifw.nl2sql.engine import _execute_query
@@ -42,8 +43,7 @@ class _FakeConn:
 
 def test_should_enforce_read_only_transaction_on_postgres():
     conn = _FakeConn("postgresql")
-    with patch("django.db.connections", {"analytics": conn}), \
-         patch("django.db.transaction") as tx:
+    with patch("django.db.connections", {"analytics": conn}), patch("django.db.transaction") as tx:
         _execute_query("SELECT 1", db_alias="analytics", max_rows=100, timeout_seconds=5)
 
     stmts = conn._cursor.executed
@@ -57,8 +57,7 @@ def test_should_enforce_read_only_transaction_on_postgres():
 def test_should_skip_read_only_when_already_in_atomic_block():
     """Cannot set READ ONLY mid-transaction; degrade to regex-only (logged)."""
     conn = _FakeConn("postgresql", in_atomic_block=True)
-    with patch("django.db.connections", {"analytics": conn}), \
-         patch("django.db.transaction") as tx:
+    with patch("django.db.connections", {"analytics": conn}), patch("django.db.transaction") as tx:
         _execute_query("SELECT 1", db_alias="analytics", max_rows=100, timeout_seconds=5)
 
     stmts = conn._cursor.executed
@@ -68,8 +67,7 @@ def test_should_skip_read_only_when_already_in_atomic_block():
 
 def test_should_not_issue_postgres_only_statements_on_sqlite():
     conn = _FakeConn("sqlite")
-    with patch("django.db.connections", {"analytics": conn}), \
-         patch("django.db.transaction") as tx:
+    with patch("django.db.connections", {"analytics": conn}), patch("django.db.transaction") as tx:
         _execute_query("SELECT 1", db_alias="analytics", max_rows=100, timeout_seconds=5)
 
     stmts = conn._cursor.executed

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -30,6 +30,7 @@ User = get_user_model()
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def provider(db):
     return LLMProvider.objects.create(
@@ -74,8 +75,12 @@ def config(action, model, provider):
 @pytest.fixture
 def result():
     return LLMResult(
-        success=True, content="ok", model="gpt-4o-mini",
-        input_tokens=100, output_tokens=50, latency_ms=200,
+        success=True,
+        content="ok",
+        model="gpt-4o-mini",
+        input_tokens=100,
+        output_tokens=50,
+        latency_ms=200,
     )
 
 
@@ -87,6 +92,7 @@ def user(db):
 # ---------------------------------------------------------------------------
 # Constants / resolution
 # ---------------------------------------------------------------------------
+
 
 def test_should_validate_known_privacy_modes():
     assert PrivacyMode.is_valid("full")
@@ -122,11 +128,10 @@ def test_should_fall_back_to_full_on_invalid_mode():
 # apply_privacy() — unit level
 # ---------------------------------------------------------------------------
 
+
 @override_settings(AIFW_PRIVACY_MODE="full")
 def test_should_pass_payload_through_unchanged_in_full_mode(user):
-    payload = apply_privacy(
-        {"user": user, "metadata": {"nl_question": "how many orders?"}}
-    )
+    payload = apply_privacy({"user": user, "metadata": {"nl_question": "how many orders?"}})
     assert payload["user"] is user
     assert payload["metadata"]["nl_question"] == "how many orders?"
     assert payload["privacy_mode"] == "full"
@@ -134,9 +139,7 @@ def test_should_pass_payload_through_unchanged_in_full_mode(user):
 
 @override_settings(AIFW_PRIVACY_MODE="pseudonymous", AIFW_PRIVACY_HMAC_SECRET="s3cr3t")
 def test_should_pseudonymise_user_and_classify_question(user):
-    payload = apply_privacy(
-        {"user": user, "metadata": {"nl_question": "how many orders?"}}
-    )
+    payload = apply_privacy({"user": user, "metadata": {"nl_question": "how many orders?"}})
     assert payload["user"] is None
     assert "nl_question" not in payload["metadata"]
     assert payload["metadata"]["topic"] == "unclassified"
@@ -153,9 +156,7 @@ def test_should_produce_stable_user_hash(user):
 
 @override_settings(AIFW_PRIVACY_MODE="anonymous")
 def test_should_strip_all_user_trace_in_anonymous_mode(user):
-    payload = apply_privacy(
-        {"user": user, "metadata": {"nl_question": "secret", "extra": 1}}
-    )
+    payload = apply_privacy({"user": user, "metadata": {"nl_question": "secret", "extra": 1}})
     assert payload["user"] is None
     assert list(payload["metadata"].keys()) == ["day_bucket"]
     assert payload["privacy_mode"] == "anonymous"
@@ -164,6 +165,7 @@ def test_should_strip_all_user_trace_in_anonymous_mode(user):
 # ---------------------------------------------------------------------------
 # Custom hook registration
 # ---------------------------------------------------------------------------
+
 
 class _ShoutHook(PrivacyHook):
     mode = "pseudonymous"
@@ -194,6 +196,7 @@ def test_should_load_custom_hook_instance_by_dotted_path(user):
 # Fail-closed
 # ---------------------------------------------------------------------------
 
+
 class _BrokenHook(PrivacyHook):
     mode = "pseudonymous"
 
@@ -206,9 +209,7 @@ class _BrokenHook(PrivacyHook):
     AIFW_PRIVACY_MODE="pseudonymous",
 )
 def test_should_fail_closed_and_scrub_pii_when_hook_raises(user):
-    payload = apply_privacy(
-        {"user": user, "metadata": {"nl_question": "leak me"}}
-    )
+    payload = apply_privacy({"user": user, "metadata": {"nl_question": "leak me"}})
     assert payload["user"] is None
     assert payload["metadata"] == {"privacy_error": True}
     assert payload["privacy_mode"] == "pseudonymous"
@@ -218,6 +219,7 @@ def test_should_fail_closed_and_scrub_pii_when_hook_raises(user):
 # E2E through _log_usage (real DB write)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 @override_settings(AIFW_PRIVACY_MODE="pseudonymous", AIFW_PRIVACY_HMAC_SECRET="k")
@@ -225,7 +227,9 @@ async def test_should_write_pseudonymous_row(config, result, user):
     from aifw.service import _log_usage
 
     await _log_usage(
-        config, result, user=user,
+        config,
+        result,
+        user=user,
         metadata={"nl_question": "how many late orders?"},
     )
 
@@ -245,7 +249,10 @@ async def test_should_write_anonymous_row(config, result, user):
 
     tenant = uuid.uuid4()
     await _log_usage(
-        config, result, user=user, tenant_id=tenant,
+        config,
+        result,
+        user=user,
+        tenant_id=tenant,
         metadata={"nl_question": "secret"},
     )
 
@@ -263,7 +270,9 @@ async def test_should_default_to_full_raw_row(config, result, user):
     from aifw.service import _log_usage
 
     await _log_usage(
-        config, result, user=user,
+        config,
+        result,
+        user=user,
         metadata={"nl_question": "how many orders?"},
     )
 
@@ -277,22 +286,27 @@ async def test_should_default_to_full_raw_row(config, result, user):
 # k-anonymity helper
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.django_db
 def test_should_suppress_buckets_below_k(action, model):
     # 3 rows for ql=5, 1 row for ql=8 → with k=3 only the ql=5 bucket survives.
     for _ in range(3):
         AIUsageLog.objects.create(
-            action_type=action, model_used=model, quality_level=5,
-            input_tokens=10, output_tokens=5,
+            action_type=action,
+            model_used=model,
+            quality_level=5,
+            input_tokens=10,
+            output_tokens=5,
         )
     AIUsageLog.objects.create(
-        action_type=action, model_used=model, quality_level=8,
-        input_tokens=10, output_tokens=5,
+        action_type=action,
+        model_used=model,
+        quality_level=8,
+        input_tokens=10,
+        output_tokens=5,
     )
 
-    buckets = list(
-        AIUsageLog.objects.aggregate_with_k_anonymity("quality_level", k=3)
-    )
+    buckets = list(AIUsageLog.objects.aggregate_with_k_anonymity("quality_level", k=3))
     assert len(buckets) == 1
     assert buckets[0]["quality_level"] == 5
     assert buckets[0]["entry_count"] == 3

--- a/tests/test_routing_integration.py
+++ b/tests/test_routing_integration.py
@@ -4,6 +4,7 @@ wired into the completion path (not just the isolated _lookup_cascade).
 Guards the 0.10.3 fix where completion()/*_stream() called the legacy
 get_model_config(action_code) and silently ignored quality_level + priority.
 """
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,12 +26,14 @@ def provider(transactional_db):
     # via sync_to_async, i.e. from a worker thread. Under the default atomic
     # test wrapper that read deadlocks on SQLite shared-cache ("table is locked").
     from aifw.models import LLMProvider
+
     return LLMProvider.objects.create(name="openai", api_key_env_var="OPENAI_API_KEY")
 
 
 @pytest.fixture()
 def models(provider):
     from aifw.models import LLMModel
+
     economy = LLMModel.objects.create(name="gpt-4o-mini", provider=provider, is_active=True)
     premium = LLMModel.objects.create(name="gpt-4o", provider=provider, is_active=True)
     return economy, premium
@@ -38,6 +41,7 @@ def models(provider):
 
 def _action(code, model, quality_level=None, priority=None):
     from aifw.models import AIActionType
+
     return AIActionType.objects.create(
         code=code,
         name=f"{code} ql={quality_level} prio={priority}",
@@ -62,12 +66,13 @@ def _fake_response(content="ok"):
 
 # ── #1: routing actually reaches litellm ──────────────────────────────────────
 
+
 @pytest.mark.django_db(transaction=True)
 def test_should_route_quality_level_to_premium_model(models):
     """completion(quality_level=8) must reach the ql=8 row's model, not catch-all."""
     economy, premium = models
     _action("story", economy, quality_level=None, priority=None)  # catch-all
-    _action("story", premium, quality_level=8, priority=None)     # premium
+    _action("story", premium, quality_level=8, priority=None)  # premium
 
     captured = {}
 
@@ -77,11 +82,11 @@ def test_should_route_quality_level_to_premium_model(models):
 
     from aifw.service import sync_completion
 
-    with patch("litellm.acompletion", side_effect=_capture), \
-         patch("aifw.service._log_usage", new=AsyncMock()):
-        result = sync_completion(
-            "story", [{"role": "user", "content": "hi"}], quality_level=8
-        )
+    with (
+        patch("litellm.acompletion", side_effect=_capture),
+        patch("aifw.service._log_usage", new=AsyncMock()),
+    ):
+        result = sync_completion("story", [{"role": "user", "content": "hi"}], quality_level=8)
 
     assert result.success is True
     assert captured["model"] == "gpt-4o"  # premium row, NOT the catch-all gpt-4o-mini
@@ -102,8 +107,10 @@ def test_should_fall_back_to_catch_all_without_quality_level(models):
 
     from aifw.service import sync_completion
 
-    with patch("litellm.acompletion", side_effect=_capture), \
-         patch("aifw.service._log_usage", new=AsyncMock()):
+    with (
+        patch("litellm.acompletion", side_effect=_capture),
+        patch("aifw.service._log_usage", new=AsyncMock()),
+    ):
         result = sync_completion("story", [{"role": "user", "content": "hi"}])
 
     assert result.success is True
@@ -114,8 +121,8 @@ def test_should_fall_back_to_catch_all_without_quality_level(models):
 def test_should_route_priority_to_matching_row(models):
     """completion(priority='quality') reaches the prio-specific row."""
     economy, premium = models
-    _action("draft", economy, quality_level=None, priority=None)        # catch-all
-    _action("draft", premium, quality_level=None, priority="quality")   # prio-only
+    _action("draft", economy, quality_level=None, priority=None)  # catch-all
+    _action("draft", premium, quality_level=None, priority="quality")  # prio-only
 
     captured = {}
 
@@ -125,14 +132,17 @@ def test_should_route_priority_to_matching_row(models):
 
     from aifw.service import sync_completion
 
-    with patch("litellm.acompletion", side_effect=_capture), \
-         patch("aifw.service._log_usage", new=AsyncMock()):
+    with (
+        patch("litellm.acompletion", side_effect=_capture),
+        patch("aifw.service._log_usage", new=AsyncMock()),
+    ):
         sync_completion("draft", [{"role": "user", "content": "hi"}], priority="quality")
 
     assert captured["model"] == "gpt-4o"
 
 
 # ── #1b: invalidation flushes the completion-config cache ─────────────────────
+
 
 def test_should_invalidate_completion_config_cache_for_code():
     """invalidate_action_cache(code) must flush 'aifw:cfg:' completion keys,
@@ -153,6 +163,7 @@ def test_should_invalidate_completion_config_cache_for_code():
 
 
 # ── #2: retry is applied to the completion call ───────────────────────────────
+
 
 @pytest.mark.asyncio
 async def test_should_retry_transient_error_then_succeed():
@@ -177,9 +188,11 @@ async def test_should_retry_transient_error_then_succeed():
         return _fake_response()
 
     # Skip tenacity's exponential backoff sleeps to keep the test fast.
-    with patch("tenacity.nap.sleep", lambda *_a, **_k: None), \
-         patch("asyncio.sleep", new=AsyncMock()), \
-         patch("litellm.acompletion", side_effect=_flaky):
+    with (
+        patch("tenacity.nap.sleep", lambda *_a, **_k: None),
+        patch("asyncio.sleep", new=AsyncMock()),
+        patch("litellm.acompletion", side_effect=_flaky),
+    ):
         response = await _acompletion_with_retry(model="gpt-4o", messages=[])
 
     assert calls["n"] == 3  # 2 transient failures, succeeded on the 3rd attempt

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -41,6 +41,7 @@ def test_llm_result_with_tool_calls():
 
 # ── LLMResult.as_json() ───────────────────────────────────────────────────
 
+
 def test_should_parse_plain_json_from_content():
     """as_json() extracts dict from plain JSON content."""
     result = LLMResult(success=True, content='{"premise": "A hero rises", "themes": ["hope"]}')
@@ -91,6 +92,7 @@ def test_should_parse_nested_json():
 
 
 # ── LLMResult.field() ─────────────────────────────────────────────────────
+
 
 def test_should_extract_bold_markdown_field():
     """field() extracts **Field:** value pattern."""

--- a/tests/test_semantic_bridge.py
+++ b/tests/test_semantic_bridge.py
@@ -3,6 +3,7 @@ Tests for aifw.nl2sql.semantic — SemanticBridge.
 
 Django-free: tests only the semantic logic, no DB required.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -21,8 +22,8 @@ def bridge() -> SemanticBridge:
 
 # ── Glossary Matching ────────────────────────────────────────────────────────
 
-class TestGlossaryMatching:
 
+class TestGlossaryMatching:
     def test_kaputt_maps_to_breakdown(self, bridge: SemanticBridge):
         hints = bridge.analyze("Welche Maschinen sind kaputt?")
         terms = [g.term for g in hints.glossary_matches]
@@ -78,8 +79,8 @@ class TestGlossaryMatching:
 
 # ── Domain Detection ─────────────────────────────────────────────────────────
 
-class TestDomainDetection:
 
+class TestDomainDetection:
     def test_casting_domain(self, bridge: SemanticBridge):
         hints = bridge.analyze("Welche Maschinen sind in Störung?")
         assert hints.domain == "casting"
@@ -105,8 +106,8 @@ class TestDomainDetection:
 
 # ── Temporal Parsing ─────────────────────────────────────────────────────────
 
-class TestTemporalParsing:
 
+class TestTemporalParsing:
     def test_diese_woche(self, bridge: SemanticBridge):
         hints = bridge.analyze("Aufträge diese Woche")
         assert hints.temporal is not None
@@ -135,8 +136,8 @@ class TestTemporalParsing:
 
 # ── Prompt Block ─────────────────────────────────────────────────────────────
 
-class TestPromptBlock:
 
+class TestPromptBlock:
     def test_prompt_block_contains_domain(self, bridge: SemanticBridge):
         hints = bridge.analyze("Maschinen in Störung")
         block = hints.to_prompt_block()
@@ -156,16 +157,18 @@ class TestPromptBlock:
 
 # ── Add Entry (runtime extensibility) ────────────────────────────────────────
 
-class TestAddEntry:
 
+class TestAddEntry:
     def test_add_entry_at_runtime(self, bridge: SemanticBridge):
-        bridge.add_entry(GlossaryEntry(
-            term="rohmaterial",
-            target_column="base_material_id",
-            target_table="casting_alloy",
-            sql_hint="FK → base_material",
-            category="synonym",
-        ))
+        bridge.add_entry(
+            GlossaryEntry(
+                term="rohmaterial",
+                target_column="base_material_id",
+                target_table="casting_alloy",
+                sql_hint="FK → base_material",
+                category="synonym",
+            )
+        )
         hints = bridge.analyze("Welches Rohmaterial wird verwendet?")
         terms = [g.term for g in hints.glossary_matches]
         assert "rohmaterial" in terms

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -19,10 +19,7 @@ def test_build_model_string_openai():
 
 
 def test_build_model_string_anthropic():
-    assert (
-        _build_model_string("anthropic", "claude-3-5-sonnet")
-        == "anthropic/claude-3-5-sonnet"
-    )
+    assert _build_model_string("anthropic", "claude-3-5-sonnet") == "anthropic/claude-3-5-sonnet"
 
 
 def test_build_model_string_case_insensitive():
@@ -53,6 +50,7 @@ def test_parse_tool_calls_empty():
 
 def test_parse_tool_calls_with_json_args():
     import json
+
     tc = MagicMock()
     tc.id = "call_abc"
     tc.function.name = "search"
@@ -80,20 +78,23 @@ def test_parse_tool_calls_with_invalid_json():
 async def test_completion_no_model_configured():
     from aifw.service import completion
 
-    with patch("aifw.service.get_model_config", new=AsyncMock(return_value={
-        "model_string": "",
-        "api_key": "",
-        "api_base": None,
-        "max_tokens": 2000,
-        "temperature": 0.7,
-        "action_id": None,
-        "model_id": None,
-        "provider_name": "",
-        "model_name": "",
-    })):
-        result = await completion(
-            "unknown_action", [{"role": "user", "content": "hi"}]
-        )
+    with patch(
+        "aifw.service.get_model_config",
+        new=AsyncMock(
+            return_value={
+                "model_string": "",
+                "api_key": "",
+                "api_base": None,
+                "max_tokens": 2000,
+                "temperature": 0.7,
+                "action_id": None,
+                "model_id": None,
+                "provider_name": "",
+                "model_name": "",
+            }
+        ),
+    ):
+        result = await completion("unknown_action", [{"role": "user", "content": "hi"}])
         assert result.success is False
         assert "unknown_action" in result.error
 
@@ -102,8 +103,10 @@ async def test_completion_no_model_configured():
 # RenderedPromptProtocol tests
 # ---------------------------------------------------------------------------
 
+
 def test_should_recognise_rendered_prompt_protocol():
     """Any object with system+user attributes satisfies RenderedPromptProtocol."""
+
     class FakeRendered:
         system = "You are a writer."
         user = "Write a chapter."
@@ -126,15 +129,18 @@ def test_should_reject_list_as_rendered_prompt():
 # Retry — only transient errors
 # ---------------------------------------------------------------------------
 
+
 def test_should_expose_transient_errors_tuple():
     """_TRANSIENT_ERRORS must not include generic Exception."""
     from aifw.service import _TRANSIENT_ERRORS
+
     assert Exception not in _TRANSIENT_ERRORS
 
 
 # ---------------------------------------------------------------------------
 # sync_completion_stream — queue-based true streaming
 # ---------------------------------------------------------------------------
+
 
 def test_should_stream_chunks_via_queue():
     """sync_completion_stream yields chunks as they arrive (true streaming)."""
@@ -159,13 +165,11 @@ def test_should_stream_chunks_via_queue():
         "temperature": 0.7,
     }
 
-    with patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)), \
-         patch("litellm.acompletion", side_effect=_fake_acompletion):
-        chunks = list(
-            sync_completion_stream(
-                "story_writing", [{"role": "user", "content": "hi"}]
-            )
-        )
+    with (
+        patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)),
+        patch("litellm.acompletion", side_effect=_fake_acompletion),
+    ):
+        chunks = list(sync_completion_stream("story_writing", [{"role": "user", "content": "hi"}]))
 
     assert chunks == ["Hello", " ", "world"]
 
@@ -185,14 +189,12 @@ def test_should_propagate_exception_from_stream():
         "temperature": 0.7,
     }
 
-    with patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)), \
-         patch("litellm.acompletion", side_effect=_failing_acompletion):
+    with (
+        patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)),
+        patch("litellm.acompletion", side_effect=_failing_acompletion),
+    ):
         with pytest.raises(RuntimeError, match="LLM exploded"):
-            list(
-                sync_completion_stream(
-                    "story_writing", [{"role": "user", "content": "hi"}]
-                )
-            )
+            list(sync_completion_stream("story_writing", [{"role": "user", "content": "hi"}]))
 
 
 @pytest.mark.asyncio
@@ -218,12 +220,12 @@ async def test_completion_success():
         "provider_name": "anthropic",
         "model_name": "claude-3-5-sonnet-20241022",
     }
-    with patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)), \
-         patch("aifw.service._log_usage", new=AsyncMock()), \
-         patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)):
-        result = await completion(
-            "story_writing", [{"role": "user", "content": "Write a story"}]
-        )
+    with (
+        patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)),
+        patch("aifw.service._log_usage", new=AsyncMock()),
+        patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)),
+    ):
+        result = await completion("story_writing", [{"role": "user", "content": "Write a story"}])
         assert result.success is True
         assert result.content == "Hello world"
         assert result.input_tokens == 10
@@ -233,6 +235,7 @@ async def test_completion_success():
 # ---------------------------------------------------------------------------
 # 0.5.0 — tenant_id / object_id / metadata propagation
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_should_pass_tenant_id_to_log_usage():
@@ -245,14 +248,21 @@ async def test_should_pass_tenant_id_to_log_usage():
     log_usage_calls = []
 
     async def _capture_log_usage(
-        config, result, user=None, tenant_id=None, object_id="", metadata=None,
+        config,
+        result,
+        user=None,
+        tenant_id=None,
+        object_id="",
+        metadata=None,
         quality_level=None,
     ):
-        log_usage_calls.append({
-            "tenant_id": tenant_id,
-            "object_id": object_id,
-            "metadata": metadata,
-        })
+        log_usage_calls.append(
+            {
+                "tenant_id": tenant_id,
+                "object_id": object_id,
+                "metadata": metadata,
+            }
+        )
 
     mock_response = MagicMock()
     mock_response.choices[0].message.content = "ok"
@@ -273,9 +283,11 @@ async def test_should_pass_tenant_id_to_log_usage():
         "provider_name": "openai",
         "model_name": "gpt-4o",
     }
-    with patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)), \
-         patch("aifw.service._log_usage", side_effect=_capture_log_usage), \
-         patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)):
+    with (
+        patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)),
+        patch("aifw.service._log_usage", side_effect=_capture_log_usage),
+        patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)),
+    ):
         await completion(
             "story_writing",
             [{"role": "user", "content": "hi"}],
@@ -298,7 +310,12 @@ async def test_should_accept_string_tenant_id():
     log_usage_calls = []
 
     async def _capture_log_usage(
-        config, result, user=None, tenant_id=None, object_id="", metadata=None,
+        config,
+        result,
+        user=None,
+        tenant_id=None,
+        object_id="",
+        metadata=None,
         quality_level=None,
     ):
         log_usage_calls.append({"tenant_id": tenant_id})
@@ -322,9 +339,11 @@ async def test_should_accept_string_tenant_id():
         "provider_name": "openai",
         "model_name": "gpt-4o",
     }
-    with patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)), \
-         patch("aifw.service._log_usage", side_effect=_capture_log_usage), \
-         patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)):
+    with (
+        patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)),
+        patch("aifw.service._log_usage", side_effect=_capture_log_usage),
+        patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)),
+    ):
         await completion(
             "story_writing",
             [{"role": "user", "content": "hi"}],
@@ -338,6 +357,7 @@ async def test_should_accept_string_tenant_id():
 # ---------------------------------------------------------------------------
 # 0.5.0 — sync_completion_with_fallback
 # ---------------------------------------------------------------------------
+
 
 def test_should_return_result_from_sync_completion_with_fallback():
     """sync_completion_with_fallback() returns LLMResult on success."""
@@ -386,6 +406,7 @@ def test_should_propagate_tenant_id_through_sync_fallback():
 # ---------------------------------------------------------------------------
 # 0.5.0 — check_action_code
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.django_db
 def test_should_return_true_for_existing_action_code():
@@ -466,6 +487,7 @@ def test_build_kwargs_applies_prompt_caching_for_anthropic():
 # stack= / patterns= / context= one-liner API (Issue #3)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_should_accept_stack_patterns_context_instead_of_messages():
     """completion() with stack+patterns renders internally and calls the LLM."""
@@ -475,10 +497,11 @@ async def test_should_accept_stack_patterns_context_instead_of_messages():
         def render_stack(self, patterns, context):
             # Return a duck-typed RenderedPrompt
             class R:
-                system = f"system:{context.get('topic','')}"
+                system = f"system:{context.get('topic', '')}"
                 user = f"user:{','.join(patterns)}"
                 few_shot_messages = []
                 response_format = None
+
             return R()
 
     mock_response = MagicMock()
@@ -500,9 +523,11 @@ async def test_should_accept_stack_patterns_context_instead_of_messages():
         "provider_name": "openai",
         "model_name": "gpt-4o",
     }
-    with patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)), \
-         patch("aifw.service._log_usage", new=AsyncMock()), \
-         patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)) as mock_llm:
+    with (
+        patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)),
+        patch("aifw.service._log_usage", new=AsyncMock()),
+        patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)) as mock_llm,
+    ):
         result = await completion(
             "story.writing",
             stack=FakeStack(),
@@ -526,11 +551,13 @@ async def test_should_prefer_stack_over_messages_when_both_given():
     class FakeStack:
         def render_stack(self, patterns, context):
             rendered_calls.append(patterns)
+
             class R:
                 system = "from-stack"
                 user = "stack-user"
                 few_shot_messages = []
                 response_format = None
+
             return R()
 
     mock_response = MagicMock()
@@ -542,13 +569,21 @@ async def test_should_prefer_stack_over_messages_when_both_given():
     mock_response.usage.completion_tokens = 3
 
     config = {
-        "model_string": "gpt-4o", "api_key": None, "api_base": None,
-        "max_tokens": 500, "temperature": 0.7,
-        "action_id": 1, "model_id": 1, "provider_name": "openai", "model_name": "gpt-4o",
+        "model_string": "gpt-4o",
+        "api_key": None,
+        "api_base": None,
+        "max_tokens": 500,
+        "temperature": 0.7,
+        "action_id": 1,
+        "model_id": 1,
+        "provider_name": "openai",
+        "model_name": "gpt-4o",
     }
-    with patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)), \
-         patch("aifw.service._log_usage", new=AsyncMock()), \
-         patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)) as mock_llm:
+    with (
+        patch("aifw.service.get_model_config", new=AsyncMock(return_value=config)),
+        patch("aifw.service._log_usage", new=AsyncMock()),
+        patch("litellm.acompletion", new=AsyncMock(return_value=mock_response)) as mock_llm,
+    ):
         await completion(
             "x",
             messages=[{"role": "user", "content": "ignored"}],

--- a/tests/test_tier.py
+++ b/tests/test_tier.py
@@ -6,6 +6,7 @@ import pytest
 @pytest.fixture()
 def provider(db):
     from aifw.models import LLMProvider
+
     return LLMProvider.objects.create(
         name="openai",
         api_key_env_var="OPENAI_API_KEY",
@@ -15,6 +16,7 @@ def provider(db):
 @pytest.fixture()
 def model(provider):
     from aifw.models import LLMModel
+
     return LLMModel.objects.create(
         name="gpt-4o",
         provider=provider,
@@ -23,6 +25,7 @@ def model(provider):
 
 
 # ── get_quality_level_for_tier ────────────────────────────────────────────────
+
 
 @pytest.mark.django_db
 def test_should_return_quality_level_for_known_tier():
@@ -67,6 +70,7 @@ def test_should_use_cache_on_second_call(monkeypatch):
 
 
 # ── TierQualityMapping model integrity ───────────────────────────────────────
+
 
 @pytest.mark.django_db
 def test_should_enforce_unique_tier():


### PR DESCRIPTION
CI-Konvergenz auf das ADR-226-Reusable `_ci-pypi.yml` (platform ADR-266 Stufe 2b, freigegeben 2026-07-04).

Ersetzt die handgerollte ci.yml durch einen Thin-Caller (Inputs aus der Vorgänger-CI abgeleitet).
Das Reusable liefert: ruff, gitleaks (History+Built-Artifact), pytest-Matrix, build+twine check, pip-audit.

**Merge-Regel:** nur bei grünem CI. Bleibt dieser PR rot, ist das ein ehrlicher Befund
(Lint-/Test-/CVE-Backlog des Repos) — dann offen lassen; Findings landen im wöchentlichen
pypi-fleet-health-Report (platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
