### PR TITLE
[feat](nl2sql): Groq-first Seed + promptfw-Prompt-Auflösung (ADR-146), tote Modell-IDs bereinigt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — aifw
 
+## [Unreleased]
+
+### Added (NL2X-Fleet-Audit WP6 — platform#913)
+- **NL2SQL-System-Prompt via promptfw (ADR-146).** `NL2SQLEngine` löst den System-Prompt jetzt zuerst über das DB-verwaltete promptfw-Template `nl2sql.system` auf (`promptfw.contrib.django.resolution.render_prompt`). Fallback ist das bisherige hardcodierte `SYSTEM_PROMPT_TEMPLATE` — Installationen **ohne** das `[promptfw]`-Extra behalten byte-identisches Verhalten (Soft-Import, gleiches Muster wie `aifw.schema.extract_json`; kein harter Bruch, keine neue Pflicht-Dependency).
+- **`init_aifw_config` seedet das promptfw-Template** `nl2sql.system` (Jinja2-Fassung des builtin Prompts), wenn promptfw installiert und migriert ist; sonst sauberer Skip.
+- **`init_aifw_config` seedet den framework-eigenen `nl2sql`-AIActionType** (catch-all): `default_model` = `groq/llama-3.3-70b-versatile`, `fallback_model` = `anthropic/claude-haiku-4-5`, `prompt_template_key` = `nl2sql.system`, `temperature` = 0.05.
+
+### Changed (Seed policy-konform — Org-LLM-Policy „free tier first")
+- **Provider-Seed:** neu `groq` (`GROQ_API_KEY`) und `cerebras` (`CEREBRAS_API_KEY`); `google` → `gemini` (`GEMINI_API_KEY`) — litellm routet Google AI Studio nur über den `gemini/`-Prefix, der bisherige Seed erzeugte den ungültigen Modell-String `google/gemini/gemini-1.5-pro`.
+- **Modell-Seed nach Policy-Tiers:** `groq/llama-3.3-70b-versatile` (Tier 1a, neuer **globaler Default**), `cerebras/gpt-oss-120b` (Tier 1a), `claude-haiku-4-5` (Tier 2), `claude-sonnet-5` (Tier 3). Der globale Default wandert damit von Anthropic Sonnet auf Groq free-tier.
+- **Tote/veraltete Modell-IDs bereinigt** (Abgleich `mcp-hub/docs/known-dead-models.txt` + litellm-Registry): `claude-3-5-sonnet-20241022` → `claude-sonnet-5` (retired 2025-10-28), `claude-3-haiku-20240307` → `claude-haiku-4-5` (retired 2026-04-19), `gemini/gemini-1.5-pro` → `gemini-2.5-pro`, `gpt-4o`/`gpt-4o-mini` (veraltet, noch bedient) → `gpt-5.1`/`gpt-5-mini`.
+- **Bestands-DBs:** die drei retired IDs werden beim Seed-Lauf deaktiviert (`is_active=False`, `is_default=False`) statt gelöscht — Usage-Historie bleibt erhalten, Routing fällt über den bestehenden Mechanismus auf aktive Modelle zurück.
+
+### Migration note (Consumer-facing)
+- Kein Breaking Change: bestehende Zeilen werden nie überschrieben (get_or_create); nur upstream-retired Modelle werden deaktiviert. Wer explizit auf eine retired ID routete, bekam upstream ohnehin 404 — nach dem Seed-Lauf greift stattdessen `fallback_model` bzw. der neue globale Default.
+
 ## [0.11.5] — 2026-06-23
 
 ### Fixed (issue #24)

--- a/src/aifw/management/commands/init_aifw_config.py
+++ b/src/aifw/management/commands/init_aifw_config.py
@@ -204,9 +204,7 @@ class Command(BaseCommand):
             model.is_default = False
             model.save(update_fields=["is_active", "is_default"])
             self.stdout.write(
-                self.style.WARNING(
-                    f"Deactivated dead model: {model.provider.name}/{model.name}"
-                )
+                self.style.WARNING(f"Deactivated dead model: {model.provider.name}/{model.name}")
             )
 
     def _seed_nl2sql_action(self):
@@ -223,9 +221,7 @@ class Command(BaseCommand):
         ).first()
         if default_model is None:
             self.stdout.write(
-                self.style.WARNING(
-                    "  Skipped AIActionType nl2sql: groq default model not found"
-                )
+                self.style.WARNING("  Skipped AIActionType nl2sql: groq default model not found")
             )
             return
         obj, created = AIActionType.objects.get_or_create(
@@ -261,8 +257,7 @@ class Command(BaseCommand):
             from promptfw.contrib.django.models import PromptTemplate
         except ImportError:
             self.stdout.write(
-                "promptfw not installed — skipped template seed "
-                f"({NL2SQL_PROMPT_KEY})."
+                f"promptfw not installed — skipped template seed ({NL2SQL_PROMPT_KEY})."
             )
             return
 
@@ -296,12 +291,8 @@ class Command(BaseCommand):
                 },
             )
         except Exception as e:  # e.g. promptfw app not in INSTALLED_APPS/migrated
-            self.stdout.write(
-                self.style.WARNING(f"  Skipped promptfw template seed: {e}")
-            )
+            self.stdout.write(self.style.WARNING(f"  Skipped promptfw template seed: {e}"))
             return
         self.stdout.write(
-            f"{'Created' if created else 'Exists'}: promptfw template "
-            f"{NL2SQL_PROMPT_KEY}"
+            f"{'Created' if created else 'Exists'}: promptfw template {NL2SQL_PROMPT_KEY}"
         )
-

--- a/src/aifw/management/commands/init_aifw_config.py
+++ b/src/aifw/management/commands/init_aifw_config.py
@@ -1,9 +1,25 @@
 """
 Seed default LLM providers and models into the DB.
 
-This command seeds infrastructure-level data only: providers and models.
+This command seeds infrastructure-level data: providers, models, and the
+framework-owned ``nl2sql`` AIActionType (aifw.nl2sql is part of this package).
 Domain-specific AIActionType entries (e.g. chapter_generation, travel_itinerary)
-belong in each consumer app's own fixture or management command.
+still belong in each consumer app's own fixture or management command.
+
+Model routing follows the org LLM policy (Groq/Cerebras free tier first,
+escalation to Claude Haiku 4.5 → Sonnet → Opus only when justified):
+
+    Tier 1a  groq/llama-3.3-70b-versatile   (global default)
+    Tier 1a  cerebras/gpt-oss-120b
+    Tier 2   anthropic/claude-haiku-4-5     (nl2sql fallback)
+    Tier 3   anthropic/claude-sonnet-5
+
+If ``iil-promptfw`` (extra ``[promptfw]``) is installed, the NL2SQL system
+prompt is additionally seeded as promptfw template ``nl2sql.system`` (ADR-146).
+
+Idempotent: get_or_create everywhere — existing rows are never overwritten.
+Known-dead upstream model IDs from earlier seeds are deactivated (see
+DEAD_MODELS), so stale rows stop being routable without deleting usage history.
 
 Usage:
     python manage.py init_aifw_config
@@ -11,9 +27,19 @@ Usage:
 
 from django.core.management.base import BaseCommand
 
-from aifw.models import LLMModel, LLMProvider
+from aifw.models import AIActionType, LLMModel, LLMProvider
 
 PROVIDERS = [
+    {
+        "name": "groq",
+        "display_name": "Groq",
+        "api_key_env_var": "GROQ_API_KEY",
+    },
+    {
+        "name": "cerebras",
+        "display_name": "Cerebras",
+        "api_key_env_var": "CEREBRAS_API_KEY",
+    },
     {
         "name": "anthropic",
         "display_name": "Anthropic",
@@ -24,10 +50,13 @@ PROVIDERS = [
         "display_name": "OpenAI",
         "api_key_env_var": "OPENAI_API_KEY",
     },
+    # litellm routes Google AI Studio via the "gemini/" prefix — a provider
+    # named "google" produced the unroutable string "google/…" (see
+    # _build_model_string in aifw.service). Fresh installs get "gemini".
     {
-        "name": "google",
-        "display_name": "Google",
-        "api_key_env_var": "GOOGLE_API_KEY",
+        "name": "gemini",
+        "display_name": "Google Gemini",
+        "api_key_env_var": "GEMINI_API_KEY",
     },
     {
         "name": "ollama",
@@ -38,57 +67,97 @@ PROVIDERS = [
 ]
 
 MODELS = [
+    # ── Tier 1a: free tier first (org policy llm-routing) ────────────────────
     {
-        "provider": "anthropic",
-        "name": "claude-3-5-sonnet-20241022",
-        "display_name": "Claude 3.5 Sonnet",
-        "max_tokens": 8192,
+        "provider": "groq",
+        "name": "llama-3.3-70b-versatile",
+        "display_name": "Llama 3.3 70B Versatile (Groq)",
+        "max_tokens": 32768,
         "supports_tools": True,
-        "input_cost_per_million": 3.0,
-        "output_cost_per_million": 15.0,
+        "input_cost_per_million": 0.59,
+        "output_cost_per_million": 0.79,
         "is_default": True,
     },
     {
-        "provider": "anthropic",
-        "name": "claude-3-haiku-20240307",
-        "display_name": "Claude 3 Haiku",
-        "max_tokens": 4096,
+        "provider": "cerebras",
+        "name": "gpt-oss-120b",
+        "display_name": "GPT-OSS 120B (Cerebras)",
+        "max_tokens": 32768,
         "supports_tools": True,
-        "input_cost_per_million": 0.25,
-        "output_cost_per_million": 1.25,
+        "input_cost_per_million": 0.35,
+        "output_cost_per_million": 0.75,
+    },
+    # ── Tier 2/3: Anthropic escalation ───────────────────────────────────────
+    {
+        "provider": "anthropic",
+        "name": "claude-haiku-4-5",
+        "display_name": "Claude Haiku 4.5",
+        "max_tokens": 64000,
+        "supports_tools": True,
+        "input_cost_per_million": 1.0,
+        "output_cost_per_million": 5.0,
     },
     {
-        "provider": "openai",
-        "name": "gpt-4o",
-        "display_name": "GPT-4o",
-        "max_tokens": 4096,
+        "provider": "anthropic",
+        "name": "claude-sonnet-5",
+        "display_name": "Claude Sonnet 5",
+        "max_tokens": 128000,
         "supports_tools": True,
-        "input_cost_per_million": 5.0,
+        "input_cost_per_million": 3.0,
         "output_cost_per_million": 15.0,
     },
+    # ── Optional non-default providers ───────────────────────────────────────
     {
         "provider": "openai",
-        "name": "gpt-4o-mini",
-        "display_name": "GPT-4o Mini",
-        "max_tokens": 4096,
+        "name": "gpt-5.1",
+        "display_name": "GPT-5.1",
+        "max_tokens": 128000,
         "supports_tools": True,
-        "input_cost_per_million": 0.15,
-        "output_cost_per_million": 0.60,
+        "input_cost_per_million": 1.25,
+        "output_cost_per_million": 10.0,
     },
     {
-        "provider": "google",
-        "name": "gemini/gemini-1.5-pro",
-        "display_name": "Gemini 1.5 Pro",
-        "max_tokens": 8192,
+        "provider": "openai",
+        "name": "gpt-5-mini",
+        "display_name": "GPT-5 Mini",
+        "max_tokens": 128000,
         "supports_tools": True,
-        "input_cost_per_million": 3.5,
-        "output_cost_per_million": 10.5,
+        "input_cost_per_million": 0.25,
+        "output_cost_per_million": 2.0,
+    },
+    {
+        "provider": "gemini",
+        "name": "gemini-2.5-pro",
+        "display_name": "Gemini 2.5 Pro",
+        "max_tokens": 65535,
+        "supports_tools": True,
+        "input_cost_per_million": 1.25,
+        "output_cost_per_million": 10.0,
     },
 ]
 
+# Seeded by earlier aifw versions, retired upstream (checked against
+# mcp-hub/docs/known-dead-models.txt + litellm model registry, 2026-07):
+#   claude-3-5-sonnet-20241022  retired 2025-10-28 (→ claude-sonnet-5)
+#   claude-3-haiku-20240307     retired 2026-04-19 (→ claude-haiku-4-5)
+#   gemini/gemini-1.5-pro       retired upstream; string also routed as the
+#                               invalid litellm prefix "google/gemini/…"
+# gpt-4o / gpt-4o-mini are outdated but still served → replaced in the seed
+# above, NOT deactivated in existing installs.
+DEAD_MODELS = frozenset(
+    {
+        "claude-3-5-sonnet-20241022",
+        "claude-3-haiku-20240307",
+        "gemini/gemini-1.5-pro",
+    }
+)
+
+# promptfw action_code of the NL2SQL system prompt (ADR-146).
+NL2SQL_PROMPT_KEY = "nl2sql.system"
+
 
 class Command(BaseCommand):
-    help = "Seed default aifw LLM providers and models (no domain-specific actions)"
+    help = "Seed default aifw LLM providers, models and the nl2sql action type"
 
     def handle(self, *args, **options):
         for p in PROVIDERS:
@@ -112,9 +181,72 @@ class Command(BaseCommand):
             )
             self.stdout.write(f"{'Created' if created else 'Exists'}: Model {obj.display_name}")
 
+        self._deactivate_dead_models()
+        self._seed_nl2sql_action()
+
         self.stdout.write(
             self.style.SUCCESS(
                 "aifw providers and models initialized.\n"
-                "Tip: run your app-specific fixture to seed AIActionType entries."
+                "Tip: run your app-specific fixture to seed further "
+                "AIActionType entries."
             )
         )
+
+    def _deactivate_dead_models(self):
+        """Deactivate models retired upstream (legacy seeds in existing DBs).
+
+        Uses .save() per row (not queryset.update) so the config-cache
+        invalidation signals fire.
+        """
+        for model in LLMModel.objects.filter(name__in=DEAD_MODELS, is_active=True):
+            model.is_active = False
+            model.is_default = False
+            model.save(update_fields=["is_active", "is_default"])
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Deactivated dead model: {model.provider.name}/{model.name}"
+                )
+            )
+
+    def _seed_nl2sql_action(self):
+        """Seed the framework-owned nl2sql AIActionType (catch-all row).
+
+        Groq free tier first (org policy), failover to Claude Haiku 4.5
+        (Tier 2) via the existing default/fallback mechanism.
+        """
+        default_model = LLMModel.objects.filter(
+            provider__name="groq", name="llama-3.3-70b-versatile"
+        ).first()
+        fallback_model = LLMModel.objects.filter(
+            provider__name="anthropic", name="claude-haiku-4-5"
+        ).first()
+        if default_model is None:
+            self.stdout.write(
+                self.style.WARNING(
+                    "  Skipped AIActionType nl2sql: groq default model not found"
+                )
+            )
+            return
+        obj, created = AIActionType.objects.get_or_create(
+            code="nl2sql",
+            quality_level=None,
+            priority=None,
+            defaults={
+                "name": "NL2SQL Text-to-SQL",
+                "description": (
+                    "SQL-Generierung aus natuerlicher Sprache "
+                    "(aifw.nl2sql.engine). Groq free-tier first, "
+                    "Failover auf Claude Haiku 4.5."
+                ),
+                "default_model": default_model,
+                "fallback_model": fallback_model,
+                "max_tokens": 2000,
+                "temperature": 0.05,
+                "prompt_template_key": NL2SQL_PROMPT_KEY,
+            },
+        )
+        self.stdout.write(
+            f"{'Created' if created else 'Exists'}: AIActionType {obj.code} "
+            f"(default={obj.default_model}, fallback={obj.fallback_model})"
+        )
+

--- a/src/aifw/management/commands/init_aifw_config.py
+++ b/src/aifw/management/commands/init_aifw_config.py
@@ -183,6 +183,7 @@ class Command(BaseCommand):
 
         self._deactivate_dead_models()
         self._seed_nl2sql_action()
+        self._seed_promptfw_template()
 
         self.stdout.write(
             self.style.SUCCESS(
@@ -248,5 +249,59 @@ class Command(BaseCommand):
         self.stdout.write(
             f"{'Created' if created else 'Exists'}: AIActionType {obj.code} "
             f"(default={obj.default_model}, fallback={obj.fallback_model})"
+        )
+
+    def _seed_promptfw_template(self):
+        """Seed the NL2SQL system prompt as promptfw template (ADR-146).
+
+        Soft dependency: silently skipped when iil-promptfw (extra
+        ``[promptfw]``) is not installed or its Django app is not migrated.
+        """
+        try:
+            from promptfw.contrib.django.models import PromptTemplate
+        except ImportError:
+            self.stdout.write(
+                "promptfw not installed — skipped template seed "
+                f"({NL2SQL_PROMPT_KEY})."
+            )
+            return
+
+        from aifw.nl2sql.engine import SYSTEM_PROMPT_TEMPLATE
+
+        # Same content as the builtin fallback, converted to Jinja2 syntax.
+        system_template = (
+            SYSTEM_PROMPT_TEMPLATE.replace("{blocked_tables}", "{{ blocked_tables }}")
+            .replace("{max_rows}", "{{ max_rows }}")
+            .replace("{schema_xml}", "{{ schema_xml }}")
+        )
+        try:
+            obj, created = PromptTemplate.objects.get_or_create(
+                action_code=NL2SQL_PROMPT_KEY,
+                version=1,
+                defaults={
+                    "name": "NL2SQL System Prompt",
+                    "description": (
+                        "System prompt of aifw.nl2sql.engine (ADR-146). "
+                        "Content mirrors the builtin SYSTEM_PROMPT_TEMPLATE."
+                    ),
+                    "system_template": system_template,
+                    "user_template": "{{ question }}",
+                    "variables_schema": {
+                        "blocked_tables": {"type": "string", "required": True},
+                        "max_rows": {"type": "integer", "required": True},
+                        "schema_xml": {"type": "string", "required": True},
+                        "question": {"type": "string", "required": True},
+                    },
+                    "domain": "nl2sql",
+                },
+            )
+        except Exception as e:  # e.g. promptfw app not in INSTALLED_APPS/migrated
+            self.stdout.write(
+                self.style.WARNING(f"  Skipped promptfw template seed: {e}")
+            )
+            return
+        self.stdout.write(
+            f"{'Created' if created else 'Exists'}: promptfw template "
+            f"{NL2SQL_PROMPT_KEY}"
         )
 

--- a/src/aifw/nl2sql/engine.py
+++ b/src/aifw/nl2sql/engine.py
@@ -6,6 +6,8 @@ Pipeline:
   1. Load SchemaSource from DB
   2. Load NL2SQLExample few-shot pairs for this source
   3. Build LLM prompt (schema XML + few-shot examples + conversation history + question)
+     — System-Prompt via promptfw-Template `nl2sql.system` (ADR-146) wenn verfügbar,
+       sonst builtin SYSTEM_PROMPT_TEMPLATE (identisches Verhalten ohne promptfw)
   4. Call sync_completion("nl2sql") via aifw service layer
   5. Extract + validate SQL from LLM response
   6. Execute SQL against target DB alias
@@ -117,6 +119,61 @@ BEWÄHRTE BEISPIELE — diese SQL-Muster sind verifiziert und korrekt.
 Verwende sie als Vorlage für ähnliche Fragen:
 
 """
+
+# promptfw action_code des NL2SQL-System-Prompts (ADR-146).
+# `init_aifw_config` seedet unter diesem Key ein DB-verwaltetes Template.
+PROMPTFW_ACTION_CODE = "nl2sql.system"
+
+
+def _builtin_system_prompt(blocked_tables: str, max_rows: int, schema_xml: str) -> str:
+    """Render the builtin (hardcoded) NL2SQL system prompt."""
+    return SYSTEM_PROMPT_TEMPLATE.format(
+        blocked_tables=blocked_tables,
+        max_rows=max_rows,
+        schema_xml=schema_xml,
+    )
+
+
+def _resolve_system_prompt(
+    question: str, blocked_tables: str, max_rows: int, schema_xml: str
+) -> str:
+    """Resolve the NL2SQL system prompt — promptfw first, builtin fallback.
+
+    Resolution order (ADR-146):
+      1. promptfw DB template ``nl2sql.system`` (via render_prompt), when
+         ``iil-promptfw`` (extra ``[promptfw]``) is installed AND the
+         template exists.
+      2. Builtin ``SYSTEM_PROMPT_TEMPLATE`` — identical behaviour for
+         installations without promptfw (soft import, same pattern as
+         ``aifw.schema.extract_json``). Never a hard break.
+    """
+    try:
+        from promptfw.contrib.django.resolution import render_prompt
+    except ImportError:
+        return _builtin_system_prompt(blocked_tables, max_rows, schema_xml)
+
+    try:
+        messages = render_prompt(
+            PROMPTFW_ACTION_CODE,
+            blocked_tables=blocked_tables,
+            max_rows=max_rows,
+            schema_xml=schema_xml,
+            question=question,
+        )
+    except Exception as exc:
+        # PromptNotFoundError, fehlende Tabelle (App nicht migriert),
+        # kaputtes Template — alles non-fatal: builtin Fallback.
+        logger.debug(
+            "promptfw-Aufloesung fuer %r nicht verfuegbar (%s) — builtin Fallback",
+            PROMPTFW_ACTION_CODE,
+            exc,
+        )
+        return _builtin_system_prompt(blocked_tables, max_rows, schema_xml)
+
+    for msg in messages:
+        if msg.get("role") == "system" and msg.get("content"):
+            return msg["content"]
+    return _builtin_system_prompt(blocked_tables, max_rows, schema_xml)
 
 
 def _extract_sql(raw: str) -> str | None:
@@ -561,7 +618,8 @@ class NL2SQLEngine:
                 logger.warning("SemanticBridge Fehler (non-fatal): %s", e)
 
         system_prompt = (
-            SYSTEM_PROMPT_TEMPLATE.format(
+            _resolve_system_prompt(
+                question=question,
                 blocked_tables=", ".join(sorted(blocked)),
                 max_rows=source.max_rows,
                 schema_xml=source.schema_xml,

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,6 +4,16 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "aifw",
 ]
+
+# promptfw is an optional extra ([promptfw], part of [dev]) — enable its
+# Django app only when installed, so the DB-template resolution path
+# (ADR-146) is exercised by tests without making promptfw a hard test dep.
+try:
+    import promptfw.contrib.django  # noqa: F401
+
+    INSTALLED_APPS.append("promptfw.contrib.django")
+except ImportError:  # pragma: no cover
+    pass
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",

--- a/tests/test_init_aifw_config.py
+++ b/tests/test_init_aifw_config.py
@@ -1,4 +1,5 @@
 """Seed command `init_aifw_config` — Groq-first policy, idempotency, cleanup."""
+
 from io import StringIO
 
 import pytest
@@ -38,9 +39,7 @@ def test_should_seed_cerebras_free_tier_model():
 def test_should_wire_nl2sql_action_groq_default_with_anthropic_fallback():
     _run_seed()
 
-    action = AIActionType.objects.get(
-        code="nl2sql", quality_level=None, priority=None
-    )
+    action = AIActionType.objects.get(code="nl2sql", quality_level=None, priority=None)
     assert action.default_model.provider.name == "groq"
     assert action.default_model.name == "llama-3.3-70b-versatile"
     assert action.fallback_model.provider.name == "anthropic"

--- a/tests/test_init_aifw_config.py
+++ b/tests/test_init_aifw_config.py
@@ -1,0 +1,116 @@
+"""Seed command `init_aifw_config` — Groq-first policy, idempotency, cleanup."""
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from aifw.models import AIActionType, LLMModel, LLMProvider
+
+
+def _run_seed() -> str:
+    out = StringIO()
+    call_command("init_aifw_config", stdout=out)
+    return out.getvalue()
+
+
+@pytest.mark.django_db
+def test_should_seed_groq_as_global_default():
+    _run_seed()
+
+    groq = LLMProvider.objects.get(name="groq")
+    assert groq.api_key_env_var == "GROQ_API_KEY"
+    model = LLMModel.objects.get(provider=groq, name="llama-3.3-70b-versatile")
+    assert model.is_default is True
+    assert model.is_active is True
+    # Exactly one global default (Tier 1a, org policy llm-routing).
+    assert LLMModel.objects.filter(is_default=True, is_active=True).count() == 1
+
+
+@pytest.mark.django_db
+def test_should_seed_cerebras_free_tier_model():
+    _run_seed()
+
+    cerebras = LLMProvider.objects.get(name="cerebras")
+    assert LLMModel.objects.filter(provider=cerebras, name="gpt-oss-120b").exists()
+
+
+@pytest.mark.django_db
+def test_should_wire_nl2sql_action_groq_default_with_anthropic_fallback():
+    _run_seed()
+
+    action = AIActionType.objects.get(
+        code="nl2sql", quality_level=None, priority=None
+    )
+    assert action.default_model.provider.name == "groq"
+    assert action.default_model.name == "llama-3.3-70b-versatile"
+    assert action.fallback_model.provider.name == "anthropic"
+    assert action.fallback_model.name == "claude-haiku-4-5"
+    assert action.prompt_template_key == "nl2sql.system"
+    assert action.temperature == pytest.approx(0.05)
+
+
+@pytest.mark.django_db
+def test_should_not_seed_dead_model_ids():
+    """Retired IDs from earlier seeds must be gone from the seed catalog."""
+    _run_seed()
+
+    dead = [
+        "claude-3-5-sonnet-20241022",
+        "claude-3-haiku-20240307",
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gemini/gemini-1.5-pro",
+    ]
+    assert not LLMModel.objects.filter(name__in=dead).exists()
+
+
+@pytest.mark.django_db
+def test_should_deactivate_legacy_dead_models_in_existing_installs():
+    provider, _ = LLMProvider.objects.get_or_create(
+        name="anthropic", defaults={"display_name": "Anthropic"}
+    )
+    legacy = LLMModel.objects.create(
+        provider=provider,
+        name="claude-3-5-sonnet-20241022",
+        display_name="Claude 3.5 Sonnet",
+        is_default=True,
+    )
+
+    _run_seed()
+
+    legacy.refresh_from_db()
+    assert legacy.is_active is False
+    assert legacy.is_default is False
+
+
+@pytest.mark.django_db
+def test_should_be_idempotent_on_second_run():
+    _run_seed()
+    counts = (
+        LLMProvider.objects.count(),
+        LLMModel.objects.count(),
+        AIActionType.objects.count(),
+    )
+
+    out = _run_seed()
+
+    assert (
+        LLMProvider.objects.count(),
+        LLMModel.objects.count(),
+        AIActionType.objects.count(),
+    ) == counts
+    assert "Created" not in out
+
+
+@pytest.mark.django_db
+def test_should_seed_promptfw_template_when_promptfw_installed():
+    pytest.importorskip("promptfw.contrib.django.models")
+    from promptfw.contrib.django.models import PromptTemplate
+
+    _run_seed()
+
+    tpl = PromptTemplate.objects.get(action_code="nl2sql.system", version=1)
+    assert "{{ blocked_tables }}" in tpl.system_template
+    assert "{{ max_rows }}" in tpl.system_template
+    assert "{{ schema_xml }}" in tpl.system_template
+    assert tpl.user_template == "{{ question }}"

--- a/tests/test_nl2sql_promptfw.py
+++ b/tests/test_nl2sql_promptfw.py
@@ -6,6 +6,7 @@ part of ``[dev]``) and skip cleanly otherwise. The fallback test forces the
 "promptfw not installed" path via ``sys.modules`` regardless of the
 environment.
 """
+
 import sys
 
 import pytest
@@ -25,9 +26,7 @@ CTX = {
 
 
 def _expected_builtin() -> str:
-    return _builtin_system_prompt(
-        CTX["blocked_tables"], CTX["max_rows"], CTX["schema_xml"]
-    )
+    return _builtin_system_prompt(CTX["blocked_tables"], CTX["max_rows"], CTX["schema_xml"])
 
 
 def test_should_fallback_to_builtin_prompt_without_promptfw(monkeypatch):

--- a/tests/test_nl2sql_promptfw.py
+++ b/tests/test_nl2sql_promptfw.py
@@ -1,0 +1,95 @@
+"""NL2SQL system-prompt resolution — promptfw first, builtin fallback (ADR-146).
+
+The promptfw-backed tests use ``pytest.importorskip`` (testing convention
+T-01): they run when the optional ``[promptfw]`` extra is installed (it is
+part of ``[dev]``) and skip cleanly otherwise. The fallback test forces the
+"promptfw not installed" path via ``sys.modules`` regardless of the
+environment.
+"""
+import sys
+
+import pytest
+
+from aifw.nl2sql.engine import (
+    PROMPTFW_ACTION_CODE,
+    _builtin_system_prompt,
+    _resolve_system_prompt,
+)
+
+CTX = {
+    "question": "Wie viele Auftraege sind offen?",
+    "blocked_tables": "auth_user, django_session",
+    "max_rows": 100,
+    "schema_xml": "<schema><table name='orders'/></schema>",
+}
+
+
+def _expected_builtin() -> str:
+    return _builtin_system_prompt(
+        CTX["blocked_tables"], CTX["max_rows"], CTX["schema_xml"]
+    )
+
+
+def test_should_fallback_to_builtin_prompt_without_promptfw(monkeypatch):
+    """Without promptfw installed the behaviour is byte-identical to before."""
+    # None in sys.modules ⇒ `import promptfw…` raises ImportError.
+    monkeypatch.setitem(sys.modules, "promptfw", None)
+
+    result = _resolve_system_prompt(**CTX)
+
+    assert result == _expected_builtin()
+    assert "auth_user, django_session" in result
+    assert "<schema><table name='orders'/></schema>" in result
+
+
+@pytest.mark.django_db
+def test_should_use_promptfw_template_when_available():
+    resolution = pytest.importorskip("promptfw.contrib.django.resolution")
+    from promptfw.contrib.django.models import PromptTemplate
+
+    resolution.invalidate_cache(PROMPTFW_ACTION_CODE)
+    try:
+        PromptTemplate.objects.create(
+            action_code=PROMPTFW_ACTION_CODE,
+            version=1,
+            system_template="CUSTOM PROMPT max_rows={{ max_rows }}",
+            user_template="{{ question }}",
+        )
+        result = _resolve_system_prompt(**CTX)
+    finally:
+        resolution.invalidate_cache(PROMPTFW_ACTION_CODE)
+
+    assert result == "CUSTOM PROMPT max_rows=100"
+
+
+@pytest.mark.django_db
+def test_should_fallback_to_builtin_when_template_missing():
+    """promptfw installed but no `nl2sql.system` row ⇒ builtin prompt."""
+    resolution = pytest.importorskip("promptfw.contrib.django.resolution")
+
+    resolution.invalidate_cache(PROMPTFW_ACTION_CODE)
+    try:
+        result = _resolve_system_prompt(**CTX)
+    finally:
+        resolution.invalidate_cache(PROMPTFW_ACTION_CODE)
+
+    assert result == _expected_builtin()
+
+
+@pytest.mark.django_db
+def test_should_render_seeded_template_identical_to_builtin():
+    """The seeded Jinja2 template renders the same content as the builtin."""
+    resolution = pytest.importorskip("promptfw.contrib.django.resolution")
+    from io import StringIO
+
+    from django.core.management import call_command
+
+    resolution.invalidate_cache(PROMPTFW_ACTION_CODE)
+    try:
+        call_command("init_aifw_config", stdout=StringIO())
+        result = _resolve_system_prompt(**CTX)
+    finally:
+        resolution.invalidate_cache(PROMPTFW_ACTION_CODE)
+
+    # render_prompt strips trailing whitespace — content must match otherwise.
+    assert result == _expected_builtin().strip()


### PR DESCRIPTION
Arbeitspaket **WP6** des NL2X-Fleet-Audits — Tracking: achimdehnert/platform#913

## Was

### 1. Seed policy-konform (Org-LLM-Policy „free tier first")
- **Provider neu:** `groq` (`GROQ_API_KEY`), `cerebras` (`CEREBRAS_API_KEY`); `google` → `gemini` (`GEMINI_API_KEY`) — litellm kennt keinen `google/`-Prefix, der Alt-Seed erzeugte den unroutbaren String `google/gemini/gemini-1.5-pro` (verifiziert gegen `litellm.provider_list` / `get_llm_provider`).
- **Modelle nach Policy-Tiers:** `groq/llama-3.3-70b-versatile` (Tier 1a, neuer globaler Default), `cerebras/gpt-oss-120b` (Tier 1a), `claude-haiku-4-5` (Tier 2), `claude-sonnet-5` (Tier 3). Opus (Tier 4, „nur begründet") bewusst nicht geseedet.
- **Tote/veraltete IDs bereinigt** (Abgleich `mcp-hub/docs/known-dead-models.txt` + litellm-Registry + claude-api-Modellkatalog):
  | alt | neu | Grund |
  |---|---|---|
  | `claude-3-5-sonnet-20241022` | `claude-sonnet-5` | retired 2025-10-28, nicht mehr in litellm `model_cost` |
  | `claude-3-haiku-20240307` | `claude-haiku-4-5` | retired 2026-04-19 (Deprecation-Datum bereits verstrichen) |
  | `gemini/gemini-1.5-pro` | `gemini-2.5-pro` (Provider `gemini`) | retired + String war litellm-unroutbar |
  | `gpt-4o` / `gpt-4o-mini` | `gpt-5.1` / `gpt-5-mini` | veraltet (Seed-Preise stimmten zudem nicht mehr); **nicht** provably dead → in Bestands-DBs nur ersetzt, nicht deaktiviert |
- **Bestands-DBs:** die drei retired IDs werden beim Seed-Lauf **deaktiviert** (`is_active=False`, `is_default=False`, via `.save()` damit Cache-Invalidierungs-Signale feuern) — Usage-Historie bleibt.
- **Neu: `nl2sql`-AIActionType** (catch-all, framework-eigen): `default_model` = Groq-Llama, `fallback_model` = Claude Haiku 4.5 (Failover-Muster über bestehendes `get_model()`), `prompt_template_key='nl2sql.system'`, `temperature=0.05`.
- Idempotent: durchgehend `get_or_create` (Bestandsmuster respektiert), zweiter Lauf erzeugt nichts.

### 2. NL2SQL-Prompt nach promptfw (ADR-146)
- `engine._resolve_system_prompt()`: zuerst DB-verwaltetes promptfw-Template `nl2sql.system` (`render_prompt`), Fallback = bisheriges `SYSTEM_PROMPT_TEMPLATE`. **Kein harter Bruch:** ohne `[promptfw]`-Extra byte-identisches Verhalten (Soft-Import, gleiches Muster wie `aifw.schema.extract_json:81`); jeder promptfw-Fehler (Template fehlt, App nicht migriert, kaputtes Template) fällt non-fatal auf builtin zurück.
- `init_aifw_config` seedet das Template (Jinja2-Fassung des builtin Prompts, `user_template='{{ question }}'`), wenn promptfw verfügbar.
- `tests/settings.py` nimmt `promptfw.contrib.django` nur bei vorhandener Installation in `INSTALLED_APPS` (PyPI `iil-promptfw>=0.8.0` enthält contrib.django inkl. Migrationen — im Wheel verifiziert; `[dev]`-Extra zieht es, CI testet also beide Pfade real).

### 3. Tests + CHANGELOG
- Neu: `test_should_use_promptfw_template_when_available`, `test_should_fallback_to_builtin_prompt_without_promptfw`, Template-fehlt-Fallback, „geseedetes Template rendert identisch zum builtin", 7 Seed-Tests (Groq-Default, Failover-Verdrahtung, keine toten IDs, Legacy-Deaktivierung, Idempotenz, promptfw-Seed).
- CHANGELOG: Unreleased-Eintrag. **Keine Versionserhöhung** — Release bleibt gated (kein PyPI-Publish durch diesen PR).

## Lokal getestet
- `make test`: **173 passed** (162 Bestand inkl. `test_nl2sql_readonly`, `test_semantic_bridge`, `test_privacy` + 11 neue), Coverage 51 % (Gate 45 %), `ruff check` sauber.
- Seed-Command zweimal real gegen SQLite-Test-DB ausgeführt (Idempotenz-Ausgabe geprüft: 2. Lauf nur `Exists:`).
- litellm-Routing der neuen Provider-Prefixe real geprüft: `get_llm_provider("groq/…")→groq`, `("cerebras/…")→cerebras`, `("google/…")→BadRequestError`.

## Bewusste Entscheidungen / Offenes
- Repo-CLAUDE.md sagt „aifw must not import iil-promptfw at runtime" (Kontext: Privacy-Hook). Der neue Soft-Import folgt dem bereits bestehenden Präzedenzfall in `aifw/schema.py` (try/except ImportError) und bricht ohne promptfw nichts — falls die Regel strikt gemeint war, bitte im Review anmerken.
- Anthropic-Preise als Listenpreise geseedet (`claude-sonnet-5`: 3/15 USD pro MTok; Intro-Preis 2/10 bis 2026-08-31 nicht abgebildet).
- Prompt-Inhalt wurde **nicht** verändert — nur die Auflösung; promptfw-`render_prompt` strippt trailing Whitespace (einziger Unterschied, per Test dokumentiert).
- „Validiert in CI" steht noch aus — bitte CI-Lauf dieses PRs abwarten (lokal grün ≠ CI grün).

🤖 Generated with [Claude Code](https://claude.com/claude-code)