### PR TITLE
feat(schema,service): LLMResult.call_id — expose AIUsageLog pk per call (REC-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added (writing-hub REC-10 — call-metadata traceability)
+- **`LLMResult.call_id`**: new additive field carrying the `AIUsageLog` row's
+  primary key for this call as a string, or `""` if usage-logging failed
+  (never raises). `model` was already present on `LLMResult` — consumers
+  needing per-call traceability (e.g. writing-hub's `LectureRevision.aifw_call_id`)
+  no longer have to add their own logging path; `_log_usage()`'s existing
+  DB write already produced this identifier, it was just discarded.
+
 ### Added (NL2X-Fleet-Audit WP6 — platform#913)
 - **NL2SQL-System-Prompt via promptfw (ADR-146).** `NL2SQLEngine` löst den System-Prompt jetzt zuerst über das DB-verwaltete promptfw-Template `nl2sql.system` auf (`promptfw.contrib.django.resolution.render_prompt`). Fallback ist das bisherige hardcodierte `SYSTEM_PROMPT_TEMPLATE` — Installationen **ohne** das `[promptfw]`-Extra behalten byte-identisches Verhalten (Soft-Import, gleiches Muster wie `aifw.schema.extract_json`; kein harter Bruch, keine neue Pflicht-Dependency).
 - **`init_aifw_config` seedet das promptfw-Template** `nl2sql.system` (Jinja2-Fassung des builtin Prompts), wenn promptfw installiert und migriert ist; sonst sauberer Skip.

--- a/src/aifw/schema.py
+++ b/src/aifw/schema.py
@@ -50,6 +50,12 @@ class LLMResult:
     output_tokens: int = 0
     latency_ms: int = 0
     error: str = ""
+    call_id: str = ""
+    """Primary key of the AIUsageLog row this call was persisted under, if
+    logging succeeded (empty string otherwise — e.g. logging failed, or the
+    call itself failed before reaching a model). Stable per-call identifier
+    consumers can store for traceability/audit (e.g. writing-hub REC-10:
+    LectureRevision.aifw_call_id)."""
 
     @property
     def has_tool_calls(self) -> bool:

--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -677,7 +677,9 @@ async def _log_usage(
     object_id: str = "",
     metadata: dict[str, Any] | None = None,
     quality_level: int | None = None,
-) -> None:
+) -> str:
+    """Persist an AIUsageLog row for this call. Returns its primary key as a
+    string (LLMResult.call_id), or "" if logging failed — never raises."""
     try:
         from aifw.models import AIActionType, AIUsageLog, LLMModel
 
@@ -739,9 +741,11 @@ async def _log_usage(
             }
         )
 
-        await sync_to_async(AIUsageLog.objects.create)(**payload)
+        log = await sync_to_async(AIUsageLog.objects.create)(**payload)
+        return str(log.id)
     except Exception as exc:
         logger.warning("Failed to log usage: %s", exc)
+        return ""
 
 
 # ---------------------------------------------------------------------------
@@ -826,7 +830,7 @@ async def completion(
             model=kwargs.get("model", ""),
         )
 
-    await _log_usage(
+    result.call_id = await _log_usage(
         config,
         result,
         user=user,

--- a/tests/test_log_usage.py
+++ b/tests/test_log_usage.py
@@ -156,6 +156,37 @@ async def test_should_default_null_when_not_provided(config, success_result):
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
+async def test_should_return_created_log_pk_as_call_id(config, success_result):
+    """_log_usage returns the created AIUsageLog's pk as a string (REC-10:
+    consumers persist this as LLMResult.call_id for traceability)."""
+    from aifw.service import _log_usage
+
+    call_id = await _log_usage(config, success_result)
+
+    log = await AIUsageLog.objects.alatest("created_at")
+    assert call_id == str(log.id)
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_should_return_empty_string_when_logging_raises(config, success_result, monkeypatch):
+    """_log_usage never raises — a DB/logging failure returns "" so the
+    caller's LLMResult.call_id degrades gracefully instead of losing the
+    actual LLM response over a logging problem."""
+    from aifw import service
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("simulated DB failure")
+
+    monkeypatch.setattr(service, "sync_to_async", lambda fn: _boom)
+
+    call_id = await service._log_usage(config, success_result)
+
+    assert call_id == ""
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
 async def test_should_write_failed_result_with_tenant_id(config):
     """_log_usage writes failed LLM result with tenant_id correctly."""
     from aifw.service import _log_usage


### PR DESCRIPTION
## Summary
- `LLMResult.call_id: str = ""` — new additive field. `_log_usage()` already creates an `AIUsageLog` row per `completion()` call but discarded its return value; now returns `str(pk)` (or `""` if logging failed — never raises) and `completion()` wires it onto the result.
- Investigated as part of writing-hub's REC-10 gap (`model_alias`/`aifw_call_id` staying empty on `LectureRevision`). Finding worth flagging: **`model_alias` needs zero aifw changes** — `LLMResult.model` already existed; writing-hub's `LLMRouter.completion()` just discards it today by returning a bare `str`. Only `aifw_call_id` needed something new here, since aifw had no call-identifier concept at all before this.

## Non-breaking
All three `LLMResult(...)` construction sites in `service.py` use kwargs exclusively — new field with a default doesn't affect them. `_log_usage()`'s return type changes `None` → `str`, but it's a private (`_`-prefixed) function with exactly one caller (`completion()`), also updated in this PR.

## Test plan
- [x] `pytest tests/` — 175 passed (173 pre-existing + 2 new: `_log_usage` returns created pk / returns `""` on failure, run against this worktree's code via explicit PYTHONPATH)
- [x] `ruff check` clean on all changed files
- [x] Verified via code read (not memory) that 3 existing routing-integration tests mock `_log_usage` with a bare `AsyncMock()` and don't assert on `call_id` — no behavior change for them

🤖 Generated with [Claude Code](https://claude.com/claude-code)