### PR TITLE
fix(ci): publish.yml auf OIDC Trusted Publishing umstellen

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
 
   publish-testpypi:


### PR DESCRIPTION
Entfernt den `password: ${{ secrets.PYPI_API_TOKEN }}`-Input → reines OIDC Trusted Publishing (id-token: write + environment bereits gesetzt). Dist **iil-aifw**. Vorbedingung: PyPI-Trusted-Publisher-Bindung auf **Repo `achimdehnert/aifw`** (nicht Dist-Name), Workflow `publish.yml`. Kein ausstehender Release — greift bei künftigen Releases. Kontext: platform#1094, ADR-266. Blueprint: [promptfw#29](https://github.com/achimdehnert/promptfw/pull/29).