### PR TITLE
fix(service): model-Override zieht den Schluessel seines Providers mit

### DIFF
--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -29,6 +29,7 @@ import json
 import logging
 import os
 import queue
+import re
 import threading
 import time
 import uuid
@@ -438,14 +439,26 @@ def _resolve_api_key(provider_name: str, env_var: str) -> str:
     """
     if env_var:
         return os.environ.get(env_var, "")
+    if not provider_name:
+        return ""
+    # Erst die ausdruecklich hinterlegten Namen, dann die Konvention
+    # <PROVIDER>_API_KEY. Die Map allein deckte vier Provider ab; groq, mistral,
+    # deepseek, together und alles Weitere fielen still auf "" — und ein leerer
+    # Schluessel liest sich beim Provider zeichengleich wie ein ungueltiger.
     fallback_map = {
         "anthropic": "ANTHROPIC_API_KEY",
         "openai": "OPENAI_API_KEY",
         "google": "GOOGLE_API_KEY",
         "gemini": "GEMINI_API_KEY",
     }
-    env_var = fallback_map.get(provider_name.lower(), "")
-    return os.environ.get(env_var, "") if env_var else ""
+    schluessel = provider_name.lower()
+    env_var = fallback_map.get(schluessel) or _env_var_name(schluessel)
+    return os.environ.get(env_var, "")
+
+
+def _env_var_name(provider_name: str) -> str:
+    """Konventioneller Variablenname eines Providers: ``<PROVIDER>_API_KEY``."""
+    return f"{re.sub(r'[^A-Z0-9]', '_', provider_name.upper())}_API_KEY"
 
 
 def _get_api_key(provider) -> str:
@@ -555,7 +568,62 @@ def _build_kwargs(
     if api_base:
         kwargs["api_base"] = api_base
     kwargs.update(overrides)
+    _follow_model_override(kwargs, config, overrides)
     return kwargs
+
+
+def _provider_of(model_string: str) -> str:
+    """Provider-Praefix eines litellm-Modellstrings, klein — '' wenn keins da ist."""
+    return model_string.split("/", 1)[0].lower() if "/" in (model_string or "") else ""
+
+
+def _follow_model_override(
+    kwargs: dict[str, Any],
+    config: dict[str, Any],
+    overrides: dict[str, Any],
+) -> None:
+    """Der Schluessel folgt dem ueberschriebenen Modell, nicht der Verdrahtung.
+
+    Ein ``model``-Override tauschte bisher nur den Modellstring; ``api_key`` blieb
+    der des VERDRAHTETEN Providers. Wer ``model="groq/..."`` gegen eine auf OpenAI
+    verdrahtete Action setzte, schickte damit den OpenAI-Schluessel an Groq und
+    bekam „Invalid API Key" — eine Meldung, die wie ein toter Schluessel aussieht,
+    obwohl beide Schluessel gueltig sind.
+
+    Das traf jeden Konsumenten, der Modelle vergleicht: writing-hub baute sich
+    dafuer eine eigene Aufloesung und musste den Schluessel bei JEDEM Aufruf
+    manuell mitgeben. Die Regel gehoert hierher — sonst kennt sie jeder Aufrufer
+    einzeln, oder eben nicht.
+
+    Ein ausdruecklich mitgegebener ``api_key`` gewinnt weiterhin: er ist die
+    explizitere Angabe, und Aufrufer mit eigener Schluesselverwaltung (bereits
+    ausgerollte Workarounds eingeschlossen) verhalten sich unveraendert.
+    """
+    if "model" not in overrides or "api_key" in overrides:
+        return
+
+    neuer_provider = _provider_of(str(overrides["model"]))
+    if not neuer_provider or neuer_provider == _provider_of(config.get("model_string", "")):
+        return
+
+    # Kein `api_key_env_var` uebergeben: der ist an den verdrahteten Provider
+    # gebunden und waere hier die falsche Antwort. Die Namenskonvention des
+    # Ziel-Providers ist die richtige.
+    key = _resolve_api_key(neuer_provider, "")
+    if key:
+        kwargs["api_key"] = key
+    else:
+        # Den fremden Schluessel NICHT stehenlassen: er scheitert garantiert und
+        # erzeugt dabei die irrefuehrendste aller Meldungen. Ohne Schluessel
+        # meldet litellm sauber, dass keiner da ist.
+        kwargs.pop("api_key", None)
+        logger.warning(
+            "model-Override auf Provider '%s', aber kein Schluessel dafuer in der Umgebung "
+            "(erwartet: %s). Der Schluessel des verdrahteten Providers wurde entfernt, "
+            "statt ihn an den fremden Provider zu schicken.",
+            neuer_provider,
+            _env_var_name(neuer_provider),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_override_follows_provider_key.py
+++ b/tests/test_model_override_follows_provider_key.py
@@ -1,0 +1,111 @@
+"""Ein ``model``-Override zieht den Schluessel seines Providers mit.
+
+Fundstelle (writing-hub, 2026-07-30): eine auf ``openai:gpt-4o-mini`` verdrahtete
+Action wurde per Override auf ``groq/qwen/qwen3.6-27b`` gesetzt. Der Modellstring
+kam bei litellm an, der ``api_key`` blieb der von OpenAI — Ergebnis „Invalid API
+Key". Die Meldung liest sich wie ein toter Schluessel, obwohl beide Schluessel
+gueltig waren; zwei Sessions suchten deshalb an der falschen Stelle.
+
+Der Konsument baute sich daraufhin eine eigene Aufloesung und gab den Schluessel
+bei jedem Aufruf manuell mit. Genau das soll hier nicht noetig sein.
+"""
+
+import pytest
+
+from aifw.service import _build_kwargs, _resolve_api_key
+
+VERDRAHTET = {
+    "model_string": "openai/gpt-4o-mini",
+    "api_key": "openai-wert",
+    "max_tokens": 2000,
+    "temperature": 0.7,
+}
+NACHRICHTEN = [{"role": "user", "content": "hallo"}]
+
+
+def _kwargs(overrides, config=None):
+    return _build_kwargs(dict(config or VERDRAHTET), NACHRICHTEN, overrides)
+
+
+def test_should_use_the_key_of_the_overridden_provider(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "groq-wert")
+    kwargs = _kwargs({"model": "groq/qwen/qwen3.6-27b"})
+    assert kwargs["api_key"] == "groq-wert"
+
+
+def test_should_keep_the_wired_key_without_an_override():
+    assert _kwargs({})["api_key"] == "openai-wert"
+
+
+def test_should_keep_the_wired_key_for_the_same_provider(monkeypatch):
+    """Modellwechsel INNERHALB des Providers laesst den Schluessel unberuehrt."""
+    monkeypatch.setenv("OPENAI_API_KEY", "anderer-wert")
+    assert _kwargs({"model": "openai/gpt-4o"})["api_key"] == "openai-wert"
+
+
+def test_should_let_an_explicit_key_win(monkeypatch):
+    """Ausgerollte Workarounds geben den Schluessel selbst mit — die bleiben gueltig."""
+    monkeypatch.setenv("GROQ_API_KEY", "groq-wert")
+    kwargs = _kwargs({"model": "groq/qwen/qwen3.6-27b", "api_key": "handgereicht"})
+    assert kwargs["api_key"] == "handgereicht"
+
+
+def test_should_drop_the_foreign_key_when_none_is_configured(monkeypatch):
+    """Ohne passenden Schluessel lieber KEINER als der fremde.
+
+    Der fremde scheitert garantiert und erzeugt dabei „Invalid API Key" — die
+    irrefuehrendste Meldung von allen. Ohne Schluessel sagt litellm sauber, dass
+    keiner da ist.
+    """
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    assert "api_key" not in _kwargs({"model": "groq/qwen/qwen3.6-27b"})
+
+
+def test_should_ignore_a_model_override_without_provider_prefix(monkeypatch):
+    """Ohne Praefix deutet litellm den Namen als OpenAI-Modell — Verdrahtung gilt."""
+    assert _kwargs({"model": "gpt-4o"})["api_key"] == "openai-wert"
+
+
+def test_should_not_touch_other_overrides(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "groq-wert")
+    kwargs = _kwargs(
+        {"model": "groq/qwen/qwen3.6-27b", "reasoning_format": "parsed", "max_tokens": 8000}
+    )
+    assert kwargs["reasoning_format"] == "parsed"
+    assert kwargs["max_tokens"] == 8000
+    assert kwargs["model"] == "groq/qwen/qwen3.6-27b"
+
+
+# --- Schluessel-Aufloesung nach Konvention ---
+
+
+@pytest.mark.parametrize(
+    "provider,env_var",
+    [
+        ("groq", "GROQ_API_KEY"),
+        ("mistral", "MISTRAL_API_KEY"),
+        ("deepseek", "DEEPSEEK_API_KEY"),
+        ("openai", "OPENAI_API_KEY"),
+    ],
+)
+def test_should_resolve_by_convention(monkeypatch, provider, env_var):
+    """Die Map deckte vier Provider ab; alle anderen fielen still auf ''."""
+    monkeypatch.setenv(env_var, f"{provider}-wert")
+    assert _resolve_api_key(provider, "") == f"{provider}-wert"
+
+
+def test_should_prefer_an_explicit_env_var(monkeypatch):
+    monkeypatch.setenv("HAUSEIGEN", "expliziter-wert")
+    monkeypatch.setenv("GROQ_API_KEY", "konventions-wert")
+    assert _resolve_api_key("groq", "HAUSEIGEN") == "expliziter-wert"
+
+
+def test_should_return_empty_for_an_unknown_provider(monkeypatch):
+    monkeypatch.delenv("PHANTASIE_API_KEY", raising=False)
+    assert _resolve_api_key("phantasie", "") == ""
+
+
+def test_should_survive_a_provider_name_with_punctuation(monkeypatch):
+    """Provider-Namen sind freier Text — der Variablenname darf davon nicht zerbrechen."""
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-wert")
+    assert _resolve_api_key("azure-openai", "") == "azure-wert"


### PR DESCRIPTION
Ein `model`-Override tauschte nur den Modellstring; `api_key` blieb der des
VERDRAHTETEN Providers. Wer `model="groq/..."` gegen eine auf OpenAI verdrahtete
Action setzte, schickte damit den OpenAI-Schluessel an Groq — "Invalid API Key",
eine Meldung, die wie ein toter Schluessel aussieht, obwohl beide gueltig sind.

Gefunden in writing-hub (2026-07-30) beim Versuch, zwei Modelle zu vergleichen.
Der Konsument baute sich daraufhin eine eigene Schluessel-Aufloesung und musste
den Schluessel bei JEDEM Aufruf manuell mitgeben. Die Regel gehoert hierher: sonst
kennt sie jeder Aufrufer einzeln — oder eben nicht.

- `_build_kwargs` loest den Schluessel neu auf, wenn der `model`-Override einen
  ANDEREN Provider nennt als die Verdrahtung. Ein ausdruecklich mitgegebener
  `api_key` gewinnt weiterhin, damit ausgerollte Workarounds unveraendert laufen.
- Ist fuer den Ziel-Provider kein Schluessel da, wird der fremde ENTFERNT statt
  weitergereicht: er scheitert garantiert und erzeugt dabei die irrefuehrendste
  aller Meldungen. Ohne Schluessel meldet litellm sauber, dass keiner da ist.
- `_resolve_api_key` faellt auf die Konvention `<PROVIDER>_API_KEY` zurueck. Die
  bisherige Map kannte vier Provider; groq, mistral, deepseek und alles Weitere
  fielen still auf "" — und ein leerer Schluessel liest sich beim Provider
  zeichengleich wie ein ungueltiger.

Verifiziert: 11 neue Tests, Suite 189 passed, ruff sauber, Coverage 51,87 %.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
