### PR TITLE
refactor(service): litellm lazy importieren — ~190 MiB RSS aus dem Boot-Pfad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Changed
+- **litellm wird lazy importiert** (platform#1899, Kriterium 3). `import aifw` zog
+  bisher ueber `aifw.cost`/`aifw.service` das komplette litellm-Paket in den
+  Django-Boot-Pfad — gemessen ~190 MiB RSS pro Prozess (web, worker UND beat),
+  auch wenn der Prozess nie einen LLM-Call macht. Jetzt laedt litellm erst beim
+  ersten Kosten- bzw. Completion-Aufruf (`_ensure_litellm()`); der Retry-Filter
+  prueft litellm-Exceptions erst im Fehlerfall (`_is_transient` statt modul-level
+  `_TRANSIENT_ERRORS`-Tupel). Wer `aifw.service.litellm`/`aifw.cost.litellm` in
+  Tests patcht, bleibt kompatibel — das Attribut existiert weiter (lazy Slot).
+  Regressionstest: `tests/test_lazy_litellm.py` (Subprozess-Probe).
+
 ## [0.11.6] — 2026-07-31
 
 ### Fixed

--- a/src/aifw/cost.py
+++ b/src/aifw/cost.py
@@ -9,10 +9,22 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
-import litellm
-
 if TYPE_CHECKING:
     from aifw.schema import LLMResult
+
+# litellm wird erst beim ersten Kostenaufruf importiert — der volle Import
+# kostet ~190 MiB RSS und gehoert nicht in den Django-Boot-Pfad (platform#1899).
+litellm = None
+
+
+def _ensure_litellm():
+    global litellm
+    if litellm is None:
+        import litellm as _litellm
+
+        litellm = _litellm
+    return litellm
+
 
 # Coarse last-resort fallback rates in $/1M tokens (input, output), keyed by
 # well-known model ids. litellm.cost_per_token() is the source of truth and
@@ -87,7 +99,7 @@ def estimate_cost(
 
     # 1. Try litellm (precise, up-to-date rates)
     try:
-        prompt_cost, completion_cost = litellm.cost_per_token(
+        prompt_cost, completion_cost = _ensure_litellm().cost_per_token(
             model=model,
             prompt_tokens=input_tokens,
             completion_tokens=output_tokens,

--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -36,7 +36,6 @@ import uuid
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
-import litellm
 from asgiref.sync import sync_to_async
 
 from aifw.constants import VALID_PRIORITIES, QualityLevel
@@ -49,7 +48,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-litellm.suppress_debug_info = True
+# litellm wird erst beim ersten LLM-Aufruf importiert — der volle Import kostet
+# ~190 MiB RSS und gehoert nicht in den Django-Boot-Pfad (platform#1899).
+litellm = None
+
+
+def _ensure_litellm():
+    global litellm
+    if litellm is None:
+        import litellm as _litellm
+
+        _litellm.suppress_debug_info = True
+        litellm = _litellm
+    return litellm
+
 
 # ---------------------------------------------------------------------------
 # Hybrid 2-layer cache
@@ -376,26 +388,31 @@ _RETRY_ENABLED: bool = True
 try:
     from tenacity import (
         retry,
-        retry_if_exception_type,
+        retry_if_exception,
         stop_after_attempt,
         wait_exponential,
     )
 
-    try:
-        from litellm.exceptions import (
-            APIConnectionError,
-            RateLimitError,
-            ServiceUnavailableError,
-            Timeout,
-        )
+    def _is_transient(exc: BaseException) -> bool:
+        # Erst im Fehlerfall aufgeloest — dann ist litellm bereits importiert;
+        # so bleibt litellm.exceptions aus dem Modul-Import-Pfad heraus.
+        try:
+            from litellm.exceptions import (
+                APIConnectionError,
+                RateLimitError,
+                ServiceUnavailableError,
+                Timeout,
+            )
+        except ImportError:
+            return isinstance(exc, Exception)
 
-        _TRANSIENT_ERRORS = (RateLimitError, ServiceUnavailableError, Timeout, APIConnectionError)
-    except ImportError:
-        _TRANSIENT_ERRORS = (Exception,)  # type: ignore[assignment]
+        return isinstance(
+            exc, (RateLimitError, ServiceUnavailableError, Timeout, APIConnectionError)
+        )
 
     def _make_retry(fn):  # type: ignore[return]
         return retry(
-            retry=retry_if_exception_type(_TRANSIENT_ERRORS),
+            retry=retry_if_exception(_is_transient),
             stop=stop_after_attempt(3),
             wait=wait_exponential(multiplier=1, min=1, max=10),
             reraise=True,
@@ -415,7 +432,7 @@ async def _acompletion_with_retry(**kwargs: Any) -> Any:
     Applied to non-streaming completions only — streaming responses must not
     be retried mid-iteration. No-op passthrough when tenacity is unavailable.
     """
-    return await litellm.acompletion(**kwargs)
+    return await _ensure_litellm().acompletion(**kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -934,7 +951,7 @@ async def completion_stream(
         if tool_choice:
             kwargs["tool_choice"] = tool_choice
 
-    response = await litellm.acompletion(**kwargs)
+    response = await _ensure_litellm().acompletion(**kwargs)
     async for chunk in response:
         delta = chunk.choices[0].delta
         if delta and delta.content:
@@ -964,7 +981,7 @@ def sync_completion_stream(
             config = await get_model_config(action_code, quality_level, priority)
             kwargs = _build_kwargs(config, messages, dict(overrides))
             kwargs["stream"] = True
-            response = await litellm.acompletion(**kwargs)
+            response = await _ensure_litellm().acompletion(**kwargs)
             async for chunk in response:
                 delta = chunk.choices[0].delta
                 if delta and delta.content:

--- a/tests/test_lazy_litellm.py
+++ b/tests/test_lazy_litellm.py
@@ -1,0 +1,34 @@
+"""Regression: aifw-Import darf litellm nicht mitladen (platform#1899).
+
+Der volle litellm-Import kostet ~190 MiB RSS; er gehoert nicht in den
+Django-Boot-Pfad. In-Prozess laesst sich das nicht pruefen, weil andere
+Tests litellm bereits geladen haben — daher Subprozess.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+
+import aifw
+
+_PROBE = (
+    "import sys; import aifw, aifw.cost, aifw.service; "
+    "sys.exit(1 if 'litellm' in sys.modules else 0)"
+)
+
+
+def test_should_not_load_litellm_on_package_import():
+    # pytest-cov-Subprozess-Hooks stoeren die Probe — Coverage-Env entfernen.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("COV_CORE")}
+    # Subprozess erbt pytests sys.path nicht — aifw-Paketwurzel explizit mitgeben.
+    pkg_root = str(pathlib.Path(aifw.__file__).resolve().parent.parent)
+    env["PYTHONPATH"] = pkg_root + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"litellm im Import-Pfad: {result.stderr}"

--- a/tests/test_routing_integration.py
+++ b/tests/test_routing_integration.py
@@ -168,12 +168,14 @@ def test_should_invalidate_completion_config_cache_for_code():
 @pytest.mark.asyncio
 async def test_should_retry_transient_error_then_succeed():
     """_acompletion_with_retry retries transient errors instead of failing once."""
-    from aifw.service import _RETRY_ENABLED, _TRANSIENT_ERRORS, _acompletion_with_retry
+    from litellm.exceptions import RateLimitError
+
+    from aifw.service import _RETRY_ENABLED, _acompletion_with_retry
 
     if not _RETRY_ENABLED:
         pytest.skip("tenacity not installed — retry layer disabled")
 
-    exc_cls = _TRANSIENT_ERRORS[0]
+    exc_cls = RateLimitError
     try:
         transient = exc_cls(message="rate limited", llm_provider="openai", model="gpt-4o")
     except TypeError:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -130,11 +130,14 @@ def test_should_reject_list_as_rendered_prompt():
 # ---------------------------------------------------------------------------
 
 
-def test_should_expose_transient_errors_tuple():
-    """_TRANSIENT_ERRORS must not include generic Exception."""
-    from aifw.service import _TRANSIENT_ERRORS
+def test_should_not_retry_generic_exceptions():
+    """_is_transient darf generische Exceptions nicht als retry-wuerdig einstufen."""
+    from litellm.exceptions import RateLimitError
 
-    assert Exception not in _TRANSIENT_ERRORS
+    from aifw.service import _is_transient
+
+    assert not _is_transient(Exception("boom"))
+    assert _is_transient(RateLimitError(message="rl", llm_provider="openai", model="gpt-4o"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Zahlt auf **[platform#1899](https://github.com/achimdehnert/platform/issues/1899), Kriterium 3** ein (Framework-Optimierung mit Messnachweis).

## Problem

`import aifw` zieht ueber `aifw.cost` und `aifw.service` das komplette litellm-Paket (inkl. openai-Client) eager in jeden Django-Prozess. Gemessen in Prod (2026-08-10, Import-RSS-Probe in drei Containern):

| Container | RSS-Kosten `import aifw` | davon litellm |
|---|---|---|
| ausschreibungs_hub_web | +191,7 MiB | ~alles (litellm solo: +192,3 MiB) |
| risk_hub_web | +188,7 MiB | dito |
| writing_hub_worker | +179,2 MiB | dito |

Betroffen ist jeder Prozess mit aifw in `INSTALLED_APPS` — web, worker **und beat**, auch wenn er nie einen LLM-Call macht. Bei ~20 Django-Containern auf hetzner-prod ist das in Summe ein niedriger einstelliger GB-Betrag an RAM allein fuer ungenutzte litellm-Importe.

## Fix

- `cost.py` / `service.py`: modul-level `import litellm` → lazy Slot (`litellm = None` + `_ensure_litellm()`); `suppress_debug_info` wird beim ersten echten Import gesetzt. Test-Patches auf `aifw.service.litellm` / `aifw.cost.litellm` bleiben kompatibel (Attribut existiert weiter).
- Retry-Konfiguration: `_TRANSIENT_ERRORS`-Tupel (brauchte `litellm.exceptions` beim Modul-Import) → `_is_transient`-Praedikat; litellm-Exceptions werden erst im Fehlerfall aufgeloest — dann ist litellm ohnehin geladen.
- Regressionstest `tests/test_lazy_litellm.py`: Subprozess-Probe, dass `import aifw, aifw.cost, aifw.service` litellm nicht laedt.

## Verifikation

- `make test`: 190 passed (vorher 187; 2 Alt-Tests auf das neue Praedikat umgestellt, 1 neuer Regressionstest)
- `ruff check` + `ruff format --check`: sauber
- Import-Probe lokal: `litellm geladen: False`

## Rollout-Hinweis

Wirksam wird das erst mit einem Release + Consumer-Bump (Owner-Go je Welle, siehe #1899 Out-of-Scope). Kein API-Bruch: `_TRANSIENT_ERRORS` war privat; oeffentliche Schnittstellen unveraendert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
