### PR TITLE
chore(release): v0.11.7 — litellm lazy import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.11.7] — 2026-08-11
+
 ### Changed
 - **litellm wird lazy importiert** (platform#1899, Kriterium 3). `import aifw` zog
   bisher ueber `aifw.cost`/`aifw.service` das komplette litellm-Paket in den

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iil-aifw"
-version = "0.11.6"
+version = "0.11.7"
 description = "Django AI Services Framework — DB-driven LLM routing, quality tiers, NL2SQL"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Version-Bump + CHANGELOG-Datierung fuer das 0.11.7-Release (Inhalt: #40, zahlt auf achimdehnert/platform#1899 K3). Owner-Go fuer Release liegt vor (Kapitaens-Kanal 2026-08-11). Nach Merge: Tag v0.11.7 -> publish.yml (OIDC, ADR-278).

🤖 Generated with [Claude Code](https://claude.com/claude-code)