### PR TITLE
chore(lint): make lint prueft dasselbe wie die CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,15 @@ test:
 test-v:
 	$(PYTHON) -m pytest tests/ --tb=short -v
 
+# Deckungsgleich mit dem CI-Lint-Job (_ci-pypi.yml): der faehrt `ruff check .`
+# UND `ruff format --check .`. Solange hier nur `ruff check src/ tests/` stand,
+# konnte `make lint` gruen sein und der Job trotzdem rot — einmal real passiert
+# (PR #39: zwei fehlende Leerzeilen in cost.py/service.py, lokal unsichtbar).
+# Wer den Umfang hier aendert, aendert ihn auch dort — sonst faellt die Luecke
+# wieder erst in der CI auf.
 lint:
-	ruff check src/ tests/
+	ruff check .
+	ruff format --check .
 
 clean:
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true


### PR DESCRIPTION
`make lint` fuhr nur `ruff check src/ tests/`. Der CI-Lint-Job (`_ci-pypi.yml`) faehrt zusaetzlich `ruff format --check .` — und ueber das ganze Repo statt nur zwei Verzeichnisse.

Dadurch konnte `make lint` lokal gruen sein und der Job trotzdem rot. Genau so passiert in #39: zwei fehlende Leerzeilen in `cost.py`/`service.py`, lokal unsichtbar, in der CI rot.

Ein Lint-Target, das weniger prueft als die CI, ist kein Vorab-Check — es ist eine Einladung zur Ueberraschung.

```
ruff check .          All checks passed!
ruff format --check . 51 files already formatted
```

Gefunden am Rand von #39 (dort geschlossen, weil v0.11.7 dieselbe Aenderung schon brachte); dieser Rest war nicht enthalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)