### PR TITLE
feat(secrets): API-Keys auch aus gemounteten Secret-Dateien lesen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### Added
+- **API-Keys werden auch aus gemounteten Secret-Dateien gelesen.**
+  `_resolve_api_key` kannte bisher nur `os.environ`. Im Betrieb werden Secrets
+  aber als **Datei** in den Container gemountet
+  (`/opt/<app>/.secrets/<name>` → `/run/secrets/<name>`), nicht als
+  Umgebungsvariable gesetzt — aifw sah einen sauber hinterlegten Schlüssel
+  dadurch schlicht nicht.
+
+  Gemessen 2026-08-10 auf Prod: drei aifw-Consumer (tax-hub, risk-hub,
+  ausschreibungs-hub), **kein einziger** mit einem LLM-Schlüssel in der
+  Umgebung. Der Fehler fällt nicht auf, weil ein leerer Schlüssel beim Provider
+  dieselbe Meldung erzeugt wie ein ungültiger („Invalid API Key").
+
+  Neue Reihenfolge — env zuerst, damit bestehende Deployments ihr Verhalten
+  nicht ändern:
+
+  1. `GROQ_API_KEY`
+  2. `GROQ_API_KEY_FILE` (Docker-/Compose-Konvention: Pfad statt Wert)
+  3. `<AIFW_SECRETS_DIR|/run/secrets>/groq_api_key`
+
+  Der Dateiinhalt wird `.strip()`-t. Das ist notwendig, nicht kosmetisch: eine
+  per `echo` erzeugte Datei endet mit `\n`, und der landet sonst im
+  Authorization-Header — wieder mit derselben Meldung wie bei einem toten
+  Schlüssel. `AIFW_SECRETS_DIR` macht das Verzeichnis überschreibbar.
+
 ## [0.11.7] — 2026-08-11
 
 ### Changed

--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -34,6 +34,7 @@ import threading
 import time
 import uuid
 from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from asgiref.sync import sync_to_async
@@ -447,15 +448,28 @@ def _build_model_string(provider_name: str, model_name: str) -> str:
     return f"{provider}/{model_name}"
 
 
-def _resolve_api_key(provider_name: str, env_var: str) -> str:
-    """Resolve an API key from the environment by explicit env var first, then
-    by a provider-name fallback map. Returns '' if nothing is configured.
+#: Verzeichnis fuer gemountete Secret-Dateien (Docker-/Compose-Konvention).
+#: Ueber AIFW_SECRETS_DIR ueberschreibbar — fuer Tests und fuer Betreiber, die
+#: woanders mounten.
+DEFAULT_SECRETS_DIR = "/run/secrets"
 
-    Kept separate from cached config so secrets are never written to the
-    shared cache — the key is re-resolved fresh on every call.
+
+def _key_aus_datei(pfad: str | Path) -> str:
+    """Liest einen Schluessel aus einer Datei. Leerstring, wenn nicht lesbar.
+
+    Das ``.strip()`` ist notwendig, nicht kosmetisch: eine per Editor oder
+    ``echo`` erzeugte Secret-Datei endet fast immer mit einem Zeilenumbruch.
+    Wandert der in den Authorization-Header, lehnt der Provider den Schluessel
+    ab — mit derselben Meldung wie bei einem wirklich ungueltigen.
     """
-    if env_var:
-        return os.environ.get(env_var, "")
+    try:
+        return Path(pfad).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _fallback_env_var(provider_name: str) -> str:
+    """Variablenname eines Providers, wenn die Action keinen hinterlegt hat."""
     if not provider_name:
         return ""
     # Erst die ausdruecklich hinterlegten Namen, dann die Konvention
@@ -469,8 +483,49 @@ def _resolve_api_key(provider_name: str, env_var: str) -> str:
         "gemini": "GEMINI_API_KEY",
     }
     schluessel = provider_name.lower()
-    env_var = fallback_map.get(schluessel) or _env_var_name(schluessel)
-    return os.environ.get(env_var, "")
+    return fallback_map.get(schluessel) or _env_var_name(schluessel)
+
+
+def _resolve_api_key(provider_name: str, env_var: str) -> str:
+    """Resolve an API key. Returns '' if nothing is configured.
+
+    Drei Quellen, in dieser Reihenfolge:
+
+    1. die Umgebungsvariable selbst (``GROQ_API_KEY``)
+    2. ``<VAR>_FILE`` — die Docker-/Compose-Konvention, den **Pfad** statt des
+       Wertes in die Umgebung zu stellen
+    3. ``<secrets-dir>/<variable in klein>`` — also ``/run/secrets/groq_api_key``
+
+    Grund fuer 2 und 3: Secrets werden im Betrieb als **Datei** in den Container
+    gemountet, nicht als Umgebungsvariable gesetzt. Solange hier nur
+    ``os.environ`` gelesen wurde, sah aifw einen sauber hinterlegten Schluessel
+    schlicht nicht. Gemessen 2026-08-10 auf Prod: drei aifw-Consumer (tax-hub,
+    risk-hub, ausschreibungs-hub), kein einziger mit einem LLM-Schluessel in der
+    Umgebung — waehrend daneben ``/opt/<app>/.secrets/<name>`` nach
+    ``/run/secrets/<name>`` gemountet wird.
+
+    Die Reihenfolge ist bewusst env-zuerst: bestehende Deployments, die den Wert
+    in der Umgebung fuehren, aendern ihr Verhalten dadurch nicht.
+
+    Kept separate from cached config so secrets are never written to the
+    shared cache — the key is re-resolved fresh on every call.
+    """
+    name = env_var or _fallback_env_var(provider_name)
+    if not name:
+        return ""
+
+    wert = os.environ.get(name, "")
+    if wert:
+        return wert
+
+    pfad = os.environ.get(f"{name}_FILE", "")
+    if pfad:
+        wert = _key_aus_datei(pfad)
+        if wert:
+            return wert
+
+    verzeichnis = os.environ.get("AIFW_SECRETS_DIR", DEFAULT_SECRETS_DIR)
+    return _key_aus_datei(Path(verzeichnis) / name.lower())
 
 
 def _env_var_name(provider_name: str) -> str:

--- a/tests/test_api_key_aus_secret_datei.py
+++ b/tests/test_api_key_aus_secret_datei.py
@@ -1,0 +1,113 @@
+"""API-Key-Aufloesung aus gemounteten Secret-Dateien.
+
+Hintergrund: Secrets werden im Betrieb als Datei in den Container gemountet
+(``/opt/<app>/.secrets/<name>`` -> ``/run/secrets/<name>``), nicht als
+Umgebungsvariable gesetzt. Solange ``_resolve_api_key`` nur ``os.environ``
+las, sah aifw einen sauber hinterlegten Schluessel nicht.
+
+Gemessen 2026-08-10 auf Prod: drei aifw-Consumer (tax-hub, risk-hub,
+ausschreibungs-hub), kein einziger mit einem LLM-Schluessel in der Umgebung.
+Der Fehler faellt nicht auf, weil ein leerer Schluessel beim Provider dieselbe
+Meldung erzeugt wie ein ungueltiger ("Invalid API Key").
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aifw.service import _resolve_api_key
+
+PROVIDER = "groq"
+VAR = "GROQ_API_KEY"
+
+
+@pytest.fixture(autouse=True)
+def saubere_umgebung(monkeypatch, tmp_path):
+    """Kein echter Schluessel und kein echtes /run/secrets im Test."""
+    for name in (VAR, f"{VAR}_FILE", "AIFW_SECRETS_DIR"):
+        monkeypatch.delenv(name, raising=False)
+    # Zeigt ins Leere, solange ein Test nichts anderes setzt — sonst wuerde der
+    # Test auf einer Maschine mit echtem /run/secrets/groq_api_key anders
+    # ausgehen als in CI.
+    monkeypatch.setenv("AIFW_SECRETS_DIR", str(tmp_path / "leer"))
+    return tmp_path
+
+
+def test_should_prefer_environment_variable_over_file(monkeypatch, saubere_umgebung):
+    """Bestandsdeployments mit Wert in der Umgebung aendern ihr Verhalten nicht."""
+    datei = saubere_umgebung / "aus_datei"
+    datei.write_text("schluessel-aus-datei")
+    monkeypatch.setenv(VAR, "schluessel-aus-env")
+    monkeypatch.setenv(f"{VAR}_FILE", str(datei))
+
+    assert _resolve_api_key(PROVIDER, VAR) == "schluessel-aus-env"
+
+
+def test_should_read_key_from_var_file_path(monkeypatch, saubere_umgebung):
+    datei = saubere_umgebung / "geheim"
+    datei.write_text("schluessel-aus-datei")
+    monkeypatch.setenv(f"{VAR}_FILE", str(datei))
+
+    assert _resolve_api_key(PROVIDER, VAR) == "schluessel-aus-datei"
+
+
+def test_should_read_key_from_mounted_secrets_directory(monkeypatch, saubere_umgebung):
+    """Der Haus-Weg: /run/secrets/<variable in klein>."""
+    secrets = saubere_umgebung / "run-secrets"
+    secrets.mkdir()
+    (secrets / "groq_api_key").write_text("schluessel-aus-mount")
+    monkeypatch.setenv("AIFW_SECRETS_DIR", str(secrets))
+
+    assert _resolve_api_key(PROVIDER, VAR) == "schluessel-aus-mount"
+
+
+def test_should_strip_trailing_newline_from_secret_file(monkeypatch, saubere_umgebung):
+    """Der Zeilenumbruch ist der eigentliche Stolperstein.
+
+    Eine per `echo` erzeugte Datei endet mit \\n. Ungestrippt landet der im
+    Authorization-Header und der Provider antwortet mit derselben Meldung wie
+    bei einem toten Schluessel.
+    """
+    datei = saubere_umgebung / "mit_umbruch"
+    datei.write_text("schluessel-mit-umbruch\n")
+    monkeypatch.setenv(f"{VAR}_FILE", str(datei))
+
+    assert _resolve_api_key(PROVIDER, VAR) == "schluessel-mit-umbruch"
+
+
+def test_should_fall_through_to_mount_when_var_file_is_missing(monkeypatch, saubere_umgebung):
+    """Ein toter <VAR>_FILE-Pfad darf den Mount-Weg nicht blockieren."""
+    secrets = saubere_umgebung / "run-secrets"
+    secrets.mkdir()
+    (secrets / "groq_api_key").write_text("schluessel-aus-mount")
+    monkeypatch.setenv(f"{VAR}_FILE", str(saubere_umgebung / "gibt-es-nicht"))
+    monkeypatch.setenv("AIFW_SECRETS_DIR", str(secrets))
+
+    assert _resolve_api_key(PROVIDER, VAR) == "schluessel-aus-mount"
+
+
+def test_should_return_empty_when_nothing_is_configured(saubere_umgebung):
+    assert _resolve_api_key(PROVIDER, VAR) == ""
+
+
+def test_should_use_provider_convention_when_action_has_no_env_var(monkeypatch, saubere_umgebung):
+    """Ohne hinterlegten Variablennamen greift <PROVIDER>_API_KEY — auch als Datei."""
+    secrets = saubere_umgebung / "run-secrets"
+    secrets.mkdir()
+    (secrets / "mistral_api_key").write_text("schluessel-mistral")
+    monkeypatch.setenv("AIFW_SECRETS_DIR", str(secrets))
+
+    assert _resolve_api_key("mistral", "") == "schluessel-mistral"
+
+
+def test_should_return_empty_for_unknown_provider_without_var(saubere_umgebung):
+    assert _resolve_api_key("", "") == ""
+
+
+def test_should_not_crash_when_secret_path_is_a_directory(monkeypatch, saubere_umgebung):
+    """Ein Verzeichnis statt einer Datei darf keine Exception werfen."""
+    verzeichnis = saubere_umgebung / "kein_file"
+    verzeichnis.mkdir()
+    monkeypatch.setenv(f"{VAR}_FILE", str(verzeichnis))
+
+    assert _resolve_api_key(PROVIDER, VAR) == ""


### PR DESCRIPTION
## Problem

`_resolve_api_key` liest ausschließlich `os.environ`. Im Betrieb werden Secrets aber als **Datei** in den Container gemountet — real vorgefunden bei risk-hub:

```
/opt/risk-hub/.secrets/email_host_password  ->  /run/secrets/email_host_password
```

aifw sieht einen so hinterlegten Schlüssel **nicht**. Es gibt keine `_FILE`-Konvention und keine `/run/secrets`-Auflösung.

**Gemessen 2026-08-10 auf Prod:** drei aifw-Consumer (tax-hub, risk-hub, ausschreibungs-hub) — **kein einziger** mit einem LLM-Schlüssel in der Container-Umgebung. Die aifw-gestützten KI-Funktionen sind damit fleet-weit nicht betriebsbereit.

Und der Fehler versteckt sich gut: ein leerer Schlüssel erzeugt beim Provider dieselbe Meldung wie ein ungültiger (`Invalid API Key`) — genau die Falle, die aifw im Kommentar zu `_resolve_api_key` selbst benennt.

## Lösung

Drei Quellen, **env zuerst**, damit bestehende Deployments ihr Verhalten nicht ändern:

| # | Quelle | Beispiel |
|---|---|---|
| 1 | Umgebungsvariable | `GROQ_API_KEY` |
| 2 | `<VAR>_FILE` — Docker-Konvention, Pfad statt Wert | `GROQ_API_KEY_FILE=/run/secrets/groq` |
| 3 | `<secrets-dir>/<variable klein>` | `/run/secrets/groq_api_key` |

`AIFW_SECRETS_DIR` macht das Verzeichnis überschreibbar (Tests, abweichende Mount-Punkte).

### Das  ist der Kern, nicht Kosmetik

Eine per Editor oder `echo` erzeugte Secret-Datei endet fast immer mit `\n`. Ungestrippt wandert der in den Authorization-Header — und der Provider antwortet mit derselben Meldung wie bei einem toten Schlüssel. Ohne diesen Schritt hätte die Änderung das Problem verlagert statt gelöst.

## Tests

9 neue, unter anderem:

- Umgebung schlägt Datei (Regressionsschutz für Bestandsdeployments)
- Zeilenumbruch wird entfernt
- toter `<VAR>_FILE`-Pfad **blockiert den Mount-Weg nicht**
- Verzeichnis statt Datei wirft nicht
- Provider-Konvention (`<PROVIDER>_API_KEY`) greift auch über Datei

Die Fixture setzt `AIFW_SECRETS_DIR` bewusst auf ein leeres Verzeichnis — sonst liefe der Test auf einer Maschine mit echtem `/run/secrets/groq_api_key` anders als in CI.

```
199 passed   ruff check + ruff format sauber
```

## Kontext

Folgt der Haus-Linie „fw-Weg immer bevorzugen, cross-repo": die Lücke liegt im Framework, also wird sie dort geschlossen — ein env-Eintrag pro Consumer hätte dasselbe N-mal geflickt. Anlass: iilgmbh/tax-hub#99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)