### PR TITLE
chore(release): v0.11.8 — API-Keys aus gemounteten Secret-Dateien

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.11.8] — 2026-08-11
+
 ### Added
 - **API-Keys werden auch aus gemounteten Secret-Dateien gelesen.**
   `_resolve_api_key` kannte bisher nur `os.environ`. Im Betrieb werden Secrets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iil-aifw"
-version = "0.11.7"
+version = "0.11.8"
 description = "Django AI Services Framework — DB-driven LLM routing, quality tiers, NL2SQL"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Release-PR nach dem Muster von #41 und #37: Version + CHANGELOG-Ueberschrift, sonst nichts.

Enthaelt:
- **#43** — `_resolve_api_key` liest Keys auch aus `<VAR>_FILE` und `/run/secrets/<variable>`, mit `.strip()` gegen den Zeilenumbruch
- **#42** — `make lint` prueft dasselbe wie der CI-Lint-Job

Anlass ist tax-hub: dort liegt der LLM-Schluessel als Datei im Secret-Store, aifw las bis 0.11.7 nur `os.environ` und sah ihn deshalb nicht — gemessen an drei Consumern auf Prod, keiner mit Key in der Umgebung.

```
199 passed   ruff check + format sauber
```

Nach dem Merge: Tag `v0.11.8` loest `publish.yml` aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)