### PR TITLE
feat(embeddings): embedding()/sync_embedding() über dieselbe Action-Verdrahtung

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+.venv-aifw/
 __pycache__/
 *.py[cod]
 *.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-08-12
+
+### Added
+- **Embeddings über dieselbe Action-Verdrahtung wie Completions.**
+  `embedding()` / `sync_embedding()` routen über `get_model_config`, also über
+  denselben Lookup-Kaskade-Pfad (ADR-097 §5.1) wie `completion()`. Ein Konsument
+  verdrahtet damit ein Embedding-Modell als ganz normale Action und hält sich
+  ohne Zusatzarbeit an die `llm-routing`-Politik, statt einen Modellstring
+  hartzukodieren.
+
+  Anlass ist tax-hub: die Steuer-Recherche erreichte auf ihrem Gold-Set
+  Recall@10 0,46 bei einer Schwelle von 0,80, und die Restlücke ist lexikalisch
+  nicht schließbar — die deutsche Snowball-Konfiguration zerlegt keine
+  Komposita („Handwerker" → `handwerk` findet `handwerkerleist` nicht), und
+  Fachsynonyme wie „Verlustvortrag" / „Verlustabzug" haben gar keine
+  Wortüberschneidung. Ein semantischer Anteil ist der einzige Weg dorthin — und
+  aifw kannte bis hier keinen einzigen Embedding-Aufruf.
+
+  Drei Punkte, die bewusst so gebaut sind:
+
+  1. **`max_tokens` und `temperature` gehen nicht mit.** Beides ist am
+     Embedding-Endpunkt kein gültiger Parameter; OpenAI antwortet darauf mit
+     400. `_build_embedding_kwargs` baut deshalb einen eigenen Satz, erbt aber
+     Modellstring, Schlüssel, `api_base` und die Regel „der Schlüssel folgt
+     einem `model`-Override" (aifw#37) unverändert.
+  2. **Die Vektoren kommen in Eingabereihenfolge zurück**, sortiert nach dem
+     `index` der Provider-Antwort statt auf deren Reihenfolge zu vertrauen. Ein
+     vertauschter Vektor erzeugt keinen Fehler — er macht nur die Suche
+     schlechter, und das fällt erst Wochen später auf.
+  3. **Ein Fehlschlag ist ein Ergebnis, keine Ausnahme** (`success=False`).
+     Wer Zehntausende Textstücke einbettet, muss einen einzelnen Stapel
+     überspringen können, ohne den Lauf zu verlieren.
+
+  Die Stapelbildung bleibt beim Aufrufer: ein Aufruf ist ein Request. Ein Lauf
+  über einen ganzen Korpus braucht ohnehin Fortschritt und Wiederaufsetzen, und
+  eine Framework-Schleife könnte bei Abbruch nicht sagen, was schon
+  geschrieben wurde.
+
+  Neu exportiert: `embedding`, `sync_embedding`, `EmbeddingResult`
+  (mit `dimensions`, `total_tokens`, `estimate_cost()`). Die Nutzung wird wie
+  bei Completions in `AIUsageLog` erfasst — Embeddings zählen als Aufruf ohne
+  Ausgabe-Token.
+
 ## [0.11.8] — 2026-08-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ else:
 
 ```python
 from aifw.service import (
-    completion,                  # async
-    sync_completion,             # sync wrapper
-    completion_with_fallback,    # async, tries fallback model on error
+    completion,  # async
+    sync_completion,  # sync wrapper
+    completion_with_fallback,  # async, tries fallback model on error
     sync_completion_with_fallback,
-    sync_completion_stream,      # streaming generator
+    sync_completion_stream,  # streaming generator
     get_quality_level_for_tier,  # tier name → QualityLevel int
-    check_action_code,           # bool — action code exists in DB
+    check_action_code,  # bool — action code exists in DB
 )
 ```
 
@@ -87,9 +87,9 @@ from aifw.constants import QualityLevel
 from aifw.service import get_quality_level_for_tier, sync_completion
 
 # Map a subscription tier to a quality level (DB-driven via TierQualityMapping)
-ql = get_quality_level_for_tier("pro")          # → QualityLevel.BALANCED (5)
-ql = get_quality_level_for_tier("premium")      # → QualityLevel.PREMIUM  (8)
-ql = get_quality_level_for_tier("freemium")     # → QualityLevel.ECONOMY  (2)
+ql = get_quality_level_for_tier("pro")  # → QualityLevel.BALANCED (5)
+ql = get_quality_level_for_tier("premium")  # → QualityLevel.PREMIUM  (8)
+ql = get_quality_level_for_tier("freemium")  # → QualityLevel.ECONOMY  (2)
 
 result = sync_completion(
     "story_writing",
@@ -120,14 +120,16 @@ Art. 5 Abs. 1 lit. c):
 ```python
 # settings.py
 from aifw.constants import PrivacyMode
-AIFW_PRIVACY_MODE = PrivacyMode.PSEUDONYMOUS   # "full" (default) | "pseudonymous" | "anonymous"
+
+AIFW_PRIVACY_MODE = PrivacyMode.PSEUDONYMOUS  # "full" (default) | "pseudonymous" | "anonymous"
 AIFW_PRIVACY_HMAC_SECRET = env("AIFW_PRIVACY_HMAC_SECRET")  # optional; falls back to SECRET_KEY
 ```
 
 ```python
 # Call site stays the same — the hook transforms the row before it is written:
 sync_completion(
-    "nl2sql", messages,
+    "nl2sql",
+    messages,
     user=request.user,
     tenant_id=user.organization_id,
     metadata={"nl_question": question},
@@ -150,12 +152,15 @@ wire a real classifier via a **custom hook**:
 # myapp/privacy.py
 from aifw.privacy import PseudonymousHook
 
+
 def my_hook():
     from promptfw import classify_topic
+
     return PseudonymousHook(topic_classifier=classify_topic)
 
+
 # settings.py
-AIFW_PRIVACY_HOOK = "myapp.privacy:my_hook"   # dotted path → PrivacyHook / subclass / factory
+AIFW_PRIVACY_HOOK = "myapp.privacy:my_hook"  # dotted path → PrivacyHook / subclass / factory
 ```
 
 A custom hook receives the create-payload dict (keys: `user`, `tenant_id`,
@@ -177,10 +182,12 @@ small groups).
 from aifw.service import sync_completion_stream
 from django.http import StreamingHttpResponse
 
+
 def stream_story(request):
     def generate():
         for chunk in sync_completion_stream("story_writing", messages):
             yield chunk
+
     return StreamingHttpResponse(generate(), content_type="text/plain")
 ```
 
@@ -245,9 +252,9 @@ AIFW_CACHE_TTL=600          # shared cache TTL in seconds  (default: 600)
 ```python
 from aifw.service import invalidate_action_cache, invalidate_tier_cache
 
-invalidate_action_cache("story_writing")   # clear one action's cache entries
-invalidate_action_cache()                  # clear all
-invalidate_tier_cache("pro")               # clear one tier
+invalidate_action_cache("story_writing")  # clear one action's cache entries
+invalidate_action_cache()  # clear all
+invalidate_tier_cache("pro")  # clear one tier
 ```
 
 ## Constants
@@ -255,10 +262,10 @@ invalidate_tier_cache("pro")               # clear one tier
 ```python
 from aifw.constants import QualityLevel
 
-QualityLevel.ECONOMY   # 2
+QualityLevel.ECONOMY  # 2
 QualityLevel.BALANCED  # 5
-QualityLevel.PREMIUM   # 8
-QualityLevel.ALL       # (2, 5, 8)
+QualityLevel.PREMIUM  # 8
+QualityLevel.ALL  # (2, 5, 8)
 ```
 
 ## Configuration
@@ -267,8 +274,8 @@ QualityLevel.ALL       # (2, 5, 8)
 
 ```python
 INSTALLED_APPS = [
-    "aifw",           # core: LLMProvider, LLMModel, AIActionType, AIUsageLog, TierQualityMapping
-    "aifw.nl2sql",    # optional: NL2SQL models + migrations (requires `nl2sql` extra)
+    "aifw",  # core: LLMProvider, LLMModel, AIActionType, AIUsageLog, TierQualityMapping
+    "aifw.nl2sql",  # optional: NL2SQL models + migrations (requires `nl2sql` extra)
 ]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iil-aifw"
-version = "0.11.8"
+version = "0.12.0"
 description = "Django AI Services Framework — DB-driven LLM routing, quality tiers, NL2SQL"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aifw/__init__.py
+++ b/src/aifw/__init__.py
@@ -19,12 +19,18 @@ from aifw.constants import PrivacyMode, QualityLevel
 from aifw.cost import cost_from_rates, estimate_cost
 from aifw.exceptions import AIFWError, ConfigurationError, OrchestrationError
 from aifw.privacy import PrivacyHook, apply_privacy, get_privacy_hook
-from aifw.schema import LLMResult, RenderedPromptProtocol, ToolCall
+from aifw.schema import (
+    EmbeddingResult,
+    LLMResult,
+    RenderedPromptProtocol,
+    ToolCall,
+)
 from aifw.service import (
     check_action_code,
     completion,
     completion_stream,
     completion_with_fallback,
+    embedding,
     get_action_config,
     get_quality_level_for_tier,
     invalidate_action_cache,
@@ -33,6 +39,7 @@ from aifw.service import (
     sync_completion,
     sync_completion_stream,
     sync_completion_with_fallback,
+    sync_embedding,
 )
 from aifw.types import ActionConfig
 
@@ -51,6 +58,7 @@ __all__ = [
     "estimate_cost",
     # Types
     "ActionConfig",
+    "EmbeddingResult",
     "LLMResult",
     "RenderedPromptProtocol",
     "ToolCall",
@@ -68,10 +76,12 @@ __all__ = [
     "completion",
     "completion_stream",
     "completion_with_fallback",
+    "embedding",
     "invalidate_config_cache",
     "sync_completion",
     "sync_completion_stream",
     "sync_completion_with_fallback",
+    "sync_embedding",
 ]
 
 # Single source of truth: the version lives in pyproject.toml and is read back

--- a/src/aifw/schema.py
+++ b/src/aifw/schema.py
@@ -123,3 +123,45 @@ class LLMResult:
         if match:
             return match.group(1).strip()
         return default
+
+
+@dataclass
+class EmbeddingResult:
+    """Ergebnis eines Embedding-Aufrufs — dieselbe Bauform wie :class:`LLMResult`.
+
+    Ein Fehlschlag ist ein Normalfall, kein Absturz: ``success=False`` mit
+    gefuelltem ``error``. Konsumenten, die ueber Zehntausende Textstuecke
+    laufen, muessen einen einzelnen fehlgeschlagenen Stapel ueberspringen
+    koennen, ohne den Lauf zu verlieren.
+    """
+
+    success: bool
+    vectors: list[list[float]] = field(default_factory=list)
+    model: str = ""
+    input_tokens: int = 0
+    latency_ms: int = 0
+    error: str = ""
+    call_id: str = ""
+    """Primary key der AIUsageLog-Zeile dieses Aufrufs, falls das Logging
+    geklappt hat (sonst leer) — analog zu :attr:`LLMResult.call_id`."""
+
+    @property
+    def dimensions(self) -> int:
+        """Laenge des ersten Vektors, 0 wenn nichts zurueckkam.
+
+        Die Dimension steht nicht im Voraus fest: sie haengt am Modell (und bei
+        OpenAI zusaetzlich am optionalen ``dimensions``-Parameter). Wer eine
+        Vektorspalte anlegt, muss sie am echten Aufruf messen, nicht raten.
+        """
+        return len(self.vectors[0]) if self.vectors else 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens
+
+    def estimate_cost(self) -> "Decimal":
+        """Kosten dieses Aufrufs. Embeddings haben nur Eingabe-Token."""
+
+        from aifw.cost import estimate_cost as _estimate_cost
+
+        return _estimate_cost(self.model, self.input_tokens, 0)

--- a/src/aifw/service.py
+++ b/src/aifw/service.py
@@ -41,7 +41,12 @@ from asgiref.sync import sync_to_async
 
 from aifw.constants import VALID_PRIORITIES, QualityLevel
 from aifw.exceptions import ConfigurationError
-from aifw.schema import LLMResult, RenderedPromptProtocol, ToolCall
+from aifw.schema import (
+    EmbeddingResult,
+    LLMResult,
+    RenderedPromptProtocol,
+    ToolCall,
+)
 from aifw.types import ActionConfig
 
 if TYPE_CHECKING:
@@ -1236,3 +1241,173 @@ def check_action_code(action_code: str) -> bool:
     except Exception as exc:
         logger.warning("check_action_code('%s') failed: %s", action_code, exc)
         return False
+
+
+# ---------------------------------------------------------------------------
+# Embeddings
+# ---------------------------------------------------------------------------
+
+
+@_make_retry
+async def _aembedding_with_retry(**kwargs: Any) -> Any:
+    """litellm.aembedding mit derselben Retry-Politik wie Completions."""
+    return await _ensure_litellm().aembedding(**kwargs)
+
+
+def _build_embedding_kwargs(
+    config: dict[str, Any],
+    texts: list[str],
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    """Wie ``_build_kwargs``, aber ohne ``max_tokens``/``temperature``.
+
+    Beides ist bei Embedding-Endpunkten kein gueltiger Parameter — OpenAI
+    antwortet darauf mit 400. Der Rest (Modellstring, Schluessel, api_base,
+    Schluessel folgt einem ``model``-Override) ist bewusst identisch, damit
+    Embeddings dieselbe Verdrahtung erben wie Completions.
+    """
+    kwargs: dict[str, Any] = {
+        "model": config["model_string"],
+        "input": texts,
+    }
+    api_key = config.get("api_key", "")
+    if api_key:
+        kwargs["api_key"] = api_key
+    api_base = config.get("api_base")
+    if api_base:
+        kwargs["api_base"] = api_base
+    kwargs.update(overrides)
+    _follow_model_override(kwargs, config, overrides)
+    return kwargs
+
+
+async def embedding(
+    action_code: str,
+    texts: list[str] | str,
+    user=None,
+    tenant_id: uuid.UUID | str | None = None,
+    object_id: str = "",
+    metadata: dict[str, Any] | None = None,
+    quality_level: int | None = None,
+    priority: str | None = None,
+    **overrides: Any,
+) -> EmbeddingResult:
+    """Vektor-Embeddings ueber dieselbe Action-Verdrahtung wie ``completion``.
+
+    Der Aufruf routet ueber ``get_model_config`` — die Action bestimmt also
+    Provider, Modell und Schluessel, genau wie bei Completions. Damit gilt die
+    llm-routing-Politik auch fuer Embeddings, ohne dass ein Konsument einen
+    Modellstring hartverdrahtet.
+
+    **Ein Aufruf = ein Request.** Die Stapelbildung bleibt beim Aufrufer: wer
+    Zehntausende Textstuecke einbettet, braucht ohnehin Fortschritt,
+    Wiederaufsetzen und eine eigene Fehlerbehandlung je Stapel — das gehoert in
+    den Konsumenten, nicht hinter eine Framework-Schleife, die bei Abbruch
+    nicht sagen kann, was schon geschrieben wurde.
+
+    Args:
+        action_code: Action-Kennung, z. B. ``"recherche_embedding"``.
+        texts: Ein Text oder eine Liste; ein einzelner String wird zu einer
+            Liste mit einem Element (die Antwort traegt dann einen Vektor).
+        overrides: Werden an litellm durchgereicht, z. B. ``dimensions=1024``
+            bei OpenAI-Modellen der 3er-Reihe.
+
+    Returns:
+        :class:`EmbeddingResult`. Die Reihenfolge der Vektoren entspricht der
+        Reihenfolge der Eingabetexte — litellm sortiert die Provider-Antwort
+        nach ``index``.
+    """
+    if isinstance(texts, str):
+        texts = [texts]
+    if not texts:
+        return EmbeddingResult(success=False, error="Keine Texte uebergeben")
+
+    config = await get_model_config(action_code, quality_level, priority)
+    kwargs = _build_embedding_kwargs(config, list(texts), dict(overrides))
+
+    if not kwargs.get("model"):
+        return EmbeddingResult(
+            success=False,
+            error=f"No model configured for action {action_code!r}",
+        )
+
+    start_time = time.perf_counter()
+    try:
+        response = await _aembedding_with_retry(**kwargs)
+        latency_ms = int((time.perf_counter() - start_time) * 1000)
+        # litellm gibt die Provider-Antwort unveraendert weiter; OpenAI liefert
+        # die Elemente mit `index`. Nach `index` sortieren statt der Reihenfolge
+        # zu vertrauen — sonst haengt ein Vektor am falschen Text, und das faellt
+        # nie als Fehler auf, sondern nur als schlechte Suche.
+        elemente = sorted(
+            response.data,
+            key=lambda d: d.get("index", 0) if isinstance(d, dict) else d.index,
+        )
+        vektoren = [(e["embedding"] if isinstance(e, dict) else e.embedding) for e in elemente]
+        result = EmbeddingResult(
+            success=True,
+            vectors=vektoren,
+            model=getattr(response, "model", None) or kwargs["model"],
+            input_tokens=getattr(response.usage, "prompt_tokens", 0)
+            or getattr(response.usage, "total_tokens", 0),
+            latency_ms=latency_ms,
+        )
+    except Exception as e:
+        latency_ms = int((time.perf_counter() - start_time) * 1000)
+        logger.exception("Embedding call failed for action '%s'", action_code)
+        result = EmbeddingResult(
+            success=False,
+            error=str(e),
+            latency_ms=latency_ms,
+            model=kwargs.get("model", ""),
+        )
+
+    # Fuer die Kostenerfassung zaehlt ein Embedding wie ein Aufruf ohne Ausgabe.
+    result.call_id = await _log_usage(
+        config,
+        LLMResult(
+            success=result.success,
+            model=result.model,
+            input_tokens=result.input_tokens,
+            output_tokens=0,
+            latency_ms=result.latency_ms,
+            error=result.error,
+        ),
+        user=user,
+        tenant_id=tenant_id,
+        object_id=object_id,
+        metadata=metadata,
+        quality_level=quality_level,
+    )
+    return result
+
+
+def sync_embedding(
+    action_code: str,
+    texts: list[str] | str,
+    user=None,
+    tenant_id: uuid.UUID | str | None = None,
+    object_id: str = "",
+    metadata: dict[str, Any] | None = None,
+    quality_level: int | None = None,
+    priority: str | None = None,
+    **overrides: Any,
+) -> EmbeddingResult:
+    """Synchroner Wrapper — sicher in Views, Celery-Tasks, Management-Commands."""
+    coro = embedding(
+        action_code=action_code,
+        texts=texts,
+        user=user,
+        tenant_id=tenant_id,
+        object_id=object_id,
+        metadata=metadata,
+        quality_level=quality_level,
+        priority=priority,
+        **overrides,
+    )
+    try:
+        asyncio.get_running_loop()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(asyncio.run, coro).result(timeout=180)
+    except RuntimeError:
+        return asyncio.run(coro)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,0 +1,167 @@
+"""Tests fuer aifw.embedding — litellm gemockt, keine echten API-Aufrufe.
+
+Der Schwerpunkt liegt auf den drei Stellen, an denen ein Embedding-Aufruf
+lautlos falsch werden kann: falsche Parameter am Endpunkt, vertauschte
+Zuordnung Vektor↔Text, und ein Fehlschlag, der als Ausnahme statt als Ergebnis
+zurueckkommt und damit einen Lauf ueber Zehntausende Textstuecke abreisst.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aifw.schema import EmbeddingResult
+from aifw.service import _build_embedding_kwargs, embedding, sync_embedding
+
+CONFIG = {
+    "model_string": "text-embedding-3-large",
+    "api_key": "sk-test-123",
+    "api_base": None,
+    "max_tokens": 2000,
+    "temperature": 0.7,
+    "action_id": None,
+    "model_id": None,
+}
+
+
+def _antwort(vektoren, tokens=42, model="text-embedding-3-large", reihenfolge=None):
+    """Provider-Antwort nachbilden; `reihenfolge` setzt die index-Werte."""
+    indizes = reihenfolge if reihenfolge is not None else list(range(len(vektoren)))
+    antwort = MagicMock()
+    antwort.data = [{"index": i, "embedding": v} for i, v in zip(indizes, vektoren, strict=True)]
+    antwort.model = model
+    antwort.usage = MagicMock(prompt_tokens=tokens, total_tokens=tokens)
+    return antwort
+
+
+class TestBuildEmbeddingKwargs:
+    def test_should_not_send_completion_only_parameters(self):
+        """`max_tokens`/`temperature` sind am Embedding-Endpunkt ungueltig (400)."""
+        kwargs = _build_embedding_kwargs(CONFIG, ["a", "b"], {})
+
+        assert "max_tokens" not in kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["input"] == ["a", "b"]
+        assert kwargs["model"] == "text-embedding-3-large"
+        assert kwargs["api_key"] == "sk-test-123"
+
+    def test_should_pass_through_provider_options(self):
+        kwargs = _build_embedding_kwargs(CONFIG, ["a"], {"dimensions": 1024})
+
+        assert kwargs["dimensions"] == 1024
+
+    def test_should_let_the_key_follow_a_model_override(self, monkeypatch):
+        """Dieselbe Regel wie bei Completions (aifw#37): Schluessel folgt Modell."""
+        monkeypatch.setenv("MISTRAL_API_KEY", "sk-mistral")
+
+        kwargs = _build_embedding_kwargs(CONFIG, ["a"], {"model": "mistral/mistral-embed"})
+
+        assert kwargs["model"] == "mistral/mistral-embed"
+        assert kwargs["api_key"] == "sk-mistral"
+
+    def test_should_omit_api_base_when_not_configured(self):
+        assert "api_base" not in _build_embedding_kwargs(CONFIG, ["a"], {})
+
+
+@pytest.mark.asyncio
+class TestEmbedding:
+    async def test_should_return_vectors_in_input_order(self):
+        """Der Provider darf durcheinander antworten — die Zuordnung nicht.
+
+        Ein vertauschter Vektor faellt nie als Fehler auf: die Suche wird nur
+        schlechter. Deshalb wird nach `index` sortiert statt der Reihenfolge
+        der Antwort zu vertrauen.
+        """
+        antwort = _antwort([[0.3], [0.1], [0.2]], reihenfolge=[2, 0, 1])
+
+        with (
+            patch("aifw.service.get_model_config", AsyncMock(return_value=CONFIG)),
+            patch("aifw.service._log_usage", AsyncMock(return_value="log-1")),
+            patch("aifw.service._aembedding_with_retry", AsyncMock(return_value=antwort)),
+        ):
+            ergebnis = await embedding("recherche_embedding", ["a", "b", "c"])
+
+        assert ergebnis.success is True
+        assert ergebnis.vectors == [[0.1], [0.2], [0.3]]
+        assert ergebnis.call_id == "log-1"
+
+    async def test_should_accept_a_single_string(self):
+        with (
+            patch("aifw.service.get_model_config", AsyncMock(return_value=CONFIG)),
+            patch("aifw.service._log_usage", AsyncMock(return_value="")),
+            patch(
+                "aifw.service._aembedding_with_retry",
+                AsyncMock(return_value=_antwort([[0.1, 0.2]])),
+            ),
+        ):
+            ergebnis = await embedding("recherche_embedding", "ein Text")
+
+        assert ergebnis.dimensions == 2
+        assert len(ergebnis.vectors) == 1
+
+    async def test_should_report_failure_as_result_not_exception(self):
+        """Ein Stapel darf scheitern, ohne den ganzen Lauf mitzunehmen."""
+        with (
+            patch("aifw.service.get_model_config", AsyncMock(return_value=CONFIG)),
+            patch("aifw.service._log_usage", AsyncMock(return_value="")),
+            patch(
+                "aifw.service._aembedding_with_retry",
+                AsyncMock(side_effect=RuntimeError("rate limited")),
+            ),
+        ):
+            ergebnis = await embedding("recherche_embedding", ["a"])
+
+        assert ergebnis.success is False
+        assert "rate limited" in ergebnis.error
+        assert ergebnis.vectors == []
+
+    async def test_should_fail_gracefully_without_a_configured_model(self):
+        with patch("aifw.service.get_model_config", AsyncMock(return_value={"model_string": ""})):
+            ergebnis = await embedding("unbekannt", ["a"])
+
+        assert ergebnis.success is False
+        assert "No model configured" in ergebnis.error
+
+    async def test_should_reject_an_empty_input_list(self):
+        ergebnis = await embedding("recherche_embedding", [])
+
+        assert ergebnis.success is False
+        assert ergebnis.vectors == []
+
+    async def test_should_count_input_tokens_for_cost_tracking(self):
+        with (
+            patch("aifw.service.get_model_config", AsyncMock(return_value=CONFIG)),
+            patch("aifw.service._log_usage", AsyncMock(return_value="")),
+            patch(
+                "aifw.service._aembedding_with_retry",
+                AsyncMock(return_value=_antwort([[0.1]], tokens=1234)),
+            ),
+        ):
+            ergebnis = await embedding("recherche_embedding", ["a"])
+
+        assert ergebnis.input_tokens == 1234
+        assert ergebnis.total_tokens == 1234
+
+
+class TestSyncEmbedding:
+    def test_should_work_outside_an_event_loop(self):
+        with (
+            patch("aifw.service.get_model_config", AsyncMock(return_value=CONFIG)),
+            patch("aifw.service._log_usage", AsyncMock(return_value="")),
+            patch(
+                "aifw.service._aembedding_with_retry",
+                AsyncMock(return_value=_antwort([[0.5]])),
+            ),
+        ):
+            ergebnis = sync_embedding("recherche_embedding", ["a"])
+
+        assert ergebnis.success is True
+        assert ergebnis.vectors == [[0.5]]
+
+
+class TestEmbeddingResult:
+    def test_should_report_dimensions_of_the_first_vector(self):
+        assert EmbeddingResult(success=True, vectors=[[0.0] * 3072]).dimensions == 3072
+
+    def test_should_report_zero_dimensions_when_empty(self):
+        assert EmbeddingResult(success=False).dimensions == 0


### PR DESCRIPTION
## Warum

aifw kannte bis hier **keinen einzigen Embedding-Aufruf**. Anlass ist tax-hub: die Steuer-Recherche erreicht auf ihrem Gold-Set Recall@10 **0,46** bei einer Schwelle von 0,80, und die Restlücke ist lexikalisch nicht schließbar. Am Postgres-Stemmer nachgemessen:

| Frage | Stem | Korpus führt | Treffer |
|---|---|---|---|
| Handwerker | `handwerk` | `handwerkerleist` | nein |
| Kleinunternehmer | `kleinunternehm` | `kleinunternehmerregel` | nein |
| Verlustvortrag | `verlustvortrag` | `verlustabzug` | nein |

Die deutsche Snowball-Konfiguration zerlegt keine Komposita, und Fachsynonyme haben gar keine Wortüberschneidung. Ein semantischer Anteil ist der einzige Weg dorthin.

## Warum im Framework und nicht im Konsumenten

tax-hub könnte litellm direkt aufrufen. Dann hätte es aber eine **zweite, unverdrahtete Modellwahl** neben der Action-Konfiguration — und die `llm-routing`-Politik gälte für Embeddings nicht mehr. Hier läuft es über dieselbe Lookup-Kaskade (`get_model_config`, ADR-097 §5.1), dieselbe Schlüsselauflösung (inkl. gemounteter Secret-Dateien aus 0.11.8) und dieselbe Nutzungserfassung in `AIUsageLog`.

## Drei bewusste Entscheidungen

1. **`max_tokens`/`temperature` gehen nicht mit** — am Embedding-Endpunkt ungültig, OpenAI antwortet mit 400. Eigener kwargs-Bau, aber Modellstring, Schlüssel, `api_base` und „der Schlüssel folgt einem `model`-Override" (#37) unverändert geerbt.
2. **Vektoren kommen in Eingabereihenfolge zurück**, sortiert nach dem `index` der Provider-Antwort statt auf deren Reihenfolge zu vertrauen. Ein vertauschter Vektor erzeugt keinen Fehler — er macht nur die Suche schlechter, und das fällt erst Wochen später auf.
3. **Ein Fehlschlag ist ein Ergebnis, keine Ausnahme** (`success=False`). Wer Zehntausende Textstücke einbettet, muss einen Stapel überspringen können, ohne den Lauf zu verlieren.

## Was bewusst NICHT drin ist

**Stapelbildung.** Ein Aufruf ist ein Request. Ein Lauf über einen ganzen Korpus braucht ohnehin Fortschritt und Wiederaufsetzen, und eine Framework-Schleife könnte bei Abbruch nicht sagen, was schon geschrieben wurde — das gehört in den Konsumenten.

## Neu exportiert

`embedding` · `sync_embedding` · `EmbeddingResult` (mit `dimensions`, `total_tokens`, `estimate_cost()`)

`dimensions` ist bewusst eine Eigenschaft des Ergebnisses und keine Konstante: die Vektorlänge hängt am Modell und bei OpenAI zusätzlich am optionalen `dimensions`-Parameter. Wer eine Vektorspalte anlegt, muss sie am echten Aufruf messen.

## Beifang (nicht vermeidbar)

`ruff` steht in den dev-deps **ohne Pin**, CI zieht damit 0.16.2 — und die formatiert erstmals auch Python-Codeblöcke in Markdown. Das README auf `main` besteht `ruff format --check .` dadurch nicht mehr. Die Normalisierung ist hier mit drin (nur Kommentar-Ausrichtung in Codeblöcken), sonst wäre der Lint-Job dieses PRs rot, ohne dass es an dieser Änderung liegt.

## Verifikation

13 neue Tests, **212 gesamt grün**, `ruff check` + `ruff format --check` sauber. Kein Test ruft eine echte API — litellm ist durchgängig gemockt.

Version **0.12.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)