### PR TITLE
ci(handover): Gate-Pin auf einen festen Tag (platform#1962)

### DIFF
--- a/.github/workflows/handoff-banner-gate.yml
+++ b/.github/workflows/handoff-banner-gate.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   handoff-banner:
-    uses: achimdehnert/platform/.github/workflows/handoff-banner-gate.yml@main
+    uses: iilgmbh/shared-ci/.github/workflows/handoff-banner-gate.yml@v1.1.7


### PR DESCRIPTION
Setzt den Pin des Frische-Gates `handover-stale-vor-merge` auf einen festen Tag. Gehört zu [achimdehnert/platform#1962](https://github.com/achimdehnert/platform/issues/1962).

## Warum

Dieses Repo rief den Gate-Workflow über einen **beweglichen oder unauflösbaren** Ref auf. Beides ist bei einem Werkzeug, dessen Zweck das Blockieren von Merges ist, die falsche Richtung:

- **`@main`**: eine Änderung am Gate wirkt hier sofort und ungetestet.
- **roher Commit-SHA**: trading-hub pinnte `698883df…` — dieser Commit ist heute in **keinem** der beiden Quell-Repos mehr auflösbar (`HTTP 422 No commit found`). Der letzte Lauf dort schlug fehl; das Gate war faktisch tot. SHAs von Branch-Commits überleben das Löschen des Branches nicht.

## Was sich ändert

Neu: `iilgmbh/shared-ci/.github/workflows/handoff-banner-gate.yml@v1.1.7` — dieselbe Quelle und derselbe Tag, den die 2026-08-13 ausgerollten Caller nutzen. Danach steht die ganze Flotte auf einer Quelle mit einem Tag.

## Verhaltensrisiko: geprüft, nicht angenommen

Die beiden Gate-Fassungen (platform@main und shared-ci@v1.1.7) unterscheiden sich **nur** darin, aus welchem Repo sie die Prüfskripte nachladen — die Logik ist Zeile für Zeile dieselbe (je 125 Zeilen, Diff zeigt ausschließlich `_platform_checks` ↔ `_shared_ci_checks`).

Auch die Prüfskripte selbst sind verhaltensgleich: `agent_handover_freshness_check.py` liegt in beiden Repos mit identischem Fenster (40 Zeilen), identischer Schwelle (30 Tage), identischer Regex und identischer `check()`-Logik. Die Kopie in platform trägt zusätzlich den KONZ-038-D8-Kopf und ist formatiert — kein Verhaltensunterschied.

`iilgmbh/shared-ci` ist **öffentlich**, der Aufruf funktioniert daher auch aus anderen Orgs ohne Cross-Org-Freigabe.

## Risiko

Eine Zeile in einer Workflow-Datei. Der Workflow läuft nur auf `pull_request` mit `contents: read`. Rücknahme ist ein `git revert`.
