### PR TITLE
chore(k2): Standard-Einstieg + AGENTS.md (pkg-agents-v1, platform#2075 K2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# iil-aifw — Agent-Kontext
+
+> Schema: pkg-agents-v1 · geprüft von `platform/tools/check_agents_md.py` ·
+> GENERIERT von `platform/tools/gen_pkg_agents_md.py` (#2075 K2, ADR-266) —
+> nicht von Hand pflegen; Fakten-Drift → Generator erneut laufen lassen.
+
+## Zweck
+
+Django AI Services Framework — DB-driven LLM routing, quality tiers, NL2SQL
+
+Details und Nutzungsbeispiele: `README.md`. Dieses Paket ist Teil der
+iil-PyPI-Fleet (Programm: platform ADR-266 / #2075).
+
+## Setup & Test (Einstiegskommando)
+
+Ein Kommando, frischer Clone, Python >=3.12:
+
+```bash
+make setup && make test
+```
+
+Keine weiteren Vorbedingungen (kein Postgres, keine Env-Variablen) — wäre das
+falsch, ist es ein Schema-Verstoß und gehört hier dokumentiert.
+
+## Public API
+
+Top-Level-Module:
+
+- `aifw`
+
+Extras: `iil-aifw[all]`, `iil-aifw[dev]`, `iil-aifw[nl2sql]`, `iil-aifw[promptfw]`, `iil-aifw[rag]`
+
+## Architektur-Constraints
+
+- Library, kein App-Code: keine Deploy-/Prod-Kopplung.
+- Änderungen an der Public API sind Semver-relevant (Frühwarn-Metrik #2075 K3).
+- CI-Kontrakt: reusable `_ci-pypi.yml` (ADR-226); `make test` muss dem
+  CI-Testlauf entsprechen.
+
+## Release
+
+Publish via `publish.yml` (OIDC) — nie manuell (ADR-226/266; Release nur über CI).

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,10 @@ clean:
 	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
 	find . -name '*.pyc' -delete 2>/dev/null || true
 	@echo "Cleaned."
+
+# Fleet-Standard-Einstieg (pkg-agents-v1, platform #2075 K2): make setup && make test
+setup:
+	python3 -m venv .venv
+	.venv/bin/pip install -U pip
+	.venv/bin/pip install -e ".[dev]" || .venv/bin/pip install -e .
+	.venv/bin/pip install pytest


### PR DESCRIPTION
Einstiegs-Normalisierung + generierte Agent-Kontextdatei (Schema pkg-agents-v1, Generator: platform/tools/gen_pkg_agents_md.py). Verifiziert im frischen Clone: make setup && make test gruen (pass). Zahlt auf achimdehnert/platform#2075 Kriterium 2 ein.